### PR TITLE
ci: fix release workflow (tauri-action@v0, publish releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,13 @@ jobs:
         run: npm ci
 
       - name: Build and upload Tauri bundles
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: v__VERSION__
           releaseName: 'Alethe v__VERSION__'
           releaseBody: 'Free desktop build of Alethe for Windows, macOS and Linux. Local app is free; cloud/sync services may be offered separately.'
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Problema

As releases não apareciam na página de Releases. As tags `v1.1.0` e `v1.2.0` existem no remote e o workflow `Release` rodou, mas **todos os 4 jobs (Windows, Linux, macOS x2) falhavam no "Set up job"**, antes de qualquer build:

```
##[error]Unable to resolve action `tauri-apps/tauri-action@v1`, unable to find version `v1`
```

O repositório `tauri-apps/tauri-action` não mantém mais a tag flutuante `v1` (a linha atual é `v0.x`, com a tag major `v0`). Sem conseguir resolver a action, o job morria na inicialização e **nenhuma release era criada**.

## Mudanças

- **`tauri-apps/tauri-action@v1` → `@v0`** — versão major válida e atual.
- **`releaseDraft: true` → `false`** — antes, mesmo que o build passasse, a release nascia como rascunho oculto. Agora publica direto na página de Releases.

## Como validar

Após o merge, disparar o workflow `Release` via `workflow_dispatch` ou reempurrar uma tag `v*` e confirmar que os bundles são gerados e a release aparece publicada.