### PR TITLE
#11 fix(terminal): restaura scroll do mouse dentro de apps TUI (tela alternativa)

### DIFF
--- a/src/components/XTermView/index.tsx
+++ b/src/components/XTermView/index.tsx
@@ -43,6 +43,7 @@ import {
   getTerminalScrollbackRows,
   getWheelScrollLines,
   normalizePastedText,
+  shouldScrollHostScrollback,
 } from './terminalInput'
 import styles from './XTermView.module.css'
 
@@ -604,6 +605,12 @@ export function XTermView({
     }
 
     const onWheel = (event: WheelEvent) => {
+      // TUIs (claude/codex) entram no buffer `alternate` e ligam mouse tracking.
+      // Lá não há scrollback do host, então scrollLines() é no-op: se a gente
+      // interceptasse o wheel (preventDefault), o evento sumia e nem o host nem
+      // a app rolavam. Deixamos seguir pro xterm, que repassa o wheel pra app.
+      // Shift força o scrollback do host (convenção iTerm2 / Windows Terminal).
+      if (!shouldScrollHostScrollback(terminal.buffer.active.type, event.shiftKey)) return
       const lines = getWheelScrollLines(event, getTerminalLineHeight())
       if (lines === 0) return
       event.preventDefault()

--- a/src/components/XTermView/terminalInput.ts
+++ b/src/components/XTermView/terminalInput.ts
@@ -12,6 +12,25 @@ export function getTerminalScrollbackRows(): number {
   return TERMINAL_SCROLLBACK_ROWS
 }
 
+/**
+ * Decide se o wheel deve rolar o scrollback do host (xterm) ou ser repassado
+ * pra app que está rodando no PTY.
+ *
+ * Shell puro fica no buffer `normal` → rolamos o scrollback local. TUIs como o
+ * `claude`/`codex` trocam pro buffer `alternate`, que NÃO tem scrollback, então
+ * `terminal.scrollLines()` é no-op; ali deixamos o evento seguir pro xterm, que
+ * repassa o wheel pra app (mouse tracking / alternate-scroll) e ela rola sozinha.
+ * `Shift+wheel` força o scrollback do host mesmo assim — convenção de iTerm2 /
+ * Windows Terminal.
+ */
+export function shouldScrollHostScrollback(
+  bufferType: 'normal' | 'alternate',
+  shiftKey: boolean,
+): boolean {
+  if (shiftKey) return true
+  return bufferType !== 'alternate'
+}
+
 export function normalizePastedText(text: string): string {
   return text.replace(/\r\n?/g, '\n').replace(/\n/g, '\r')
 }

--- a/tests/XTermView/terminalInput.test.ts
+++ b/tests/XTermView/terminalInput.test.ts
@@ -6,6 +6,7 @@ import {
   getTerminalScrollbackRows,
   getWheelScrollLines,
   normalizePastedText,
+  shouldScrollHostScrollback,
 } from '../../src/components/XTermView/terminalInput.ts'
 
 test('normalizePastedText converts clipboard newlines to PTY carriage returns', () => {
@@ -25,6 +26,20 @@ test('getWheelScrollLines preserves larger wheel intent across delta modes', () 
 
 test('getTerminalScrollbackRows keeps enough rows for long agent chats', () => {
   assert.ok(getTerminalScrollbackRows() >= 10_000)
+})
+
+test('shouldScrollHostScrollback scrolls the host buffer in a plain shell', () => {
+  assert.equal(shouldScrollHostScrollback('normal', false), true)
+})
+
+test('shouldScrollHostScrollback forwards the wheel to TUIs in the alternate buffer', () => {
+  // claude/codex run in the alternate screen (no host scrollback) — let the app scroll itself.
+  assert.equal(shouldScrollHostScrollback('alternate', false), false)
+})
+
+test('shouldScrollHostScrollback lets Shift+wheel force host scrollback even in the alternate buffer', () => {
+  assert.equal(shouldScrollHostScrollback('alternate', true), true)
+  assert.equal(shouldScrollHostScrollback('normal', true), true)
 })
 
 test('formatDroppedPaths leaves space-free paths unquoted with a trailing space', () => {


### PR DESCRIPTION
Closes #<número-da-issue>

## Resumo

O scroll do mouse não fazia nada dentro de TUIs de agente como `claude` / `codex`. O único jeito de ver o output anterior era arrastar uma seleção de texto pra cima pra forçar o viewport a rolar. Shells puros rolavam normalmente.

Esta PR corrige o handler de wheel pra que TUIs voltem a rolar, tanto em janela quanto maximizado, e adiciona `Shift`+wheel pra forçar o scrollback do host.

## Causa raiz

O handler de wheel customizado do `XTermView` sequestrava **todo** evento de wheel incondicionalmente — `preventDefault()` + `stopPropagation()` + `terminal.scrollLines()`:

- Um **shell puro** roda no buffer de tela **normal** do xterm, que tem scrollback, então `scrollLines()` funcionava.
- Uma **TUI** troca pro buffer de tela **alternate**, que **não tem scrollback**, então `scrollLines()` vira no-op. O handler ainda chamava `preventDefault()`, então o evento de wheel era engolido: o host não rolava, e o evento nunca chegava no caminho nativo do xterm que repassa o scroll pra app (mouse reporting / alternate-scroll). Resultado: o wheel não fazia nada, enquanto o auto-scroll de seleção interno do xterm continuava funcionando — por isso arrastar uma seleção era o único contorno.

## Correção

Condiciona o sequestro do scrollback do host ao tipo de buffer ativo:

- **Buffer normal** (shells): rola o scrollback do host (comportamento inalterado).
- **Buffer alternate** (TUIs): deixa o wheel propagar pro xterm, que repassa pra app rolar sozinha.
- **`Shift`+wheel**: sempre força o scrollback do host, independente do buffer (convenção iTerm2 / Windows Terminal).

A decisão foi extraída pra um helper puro, fácil de testar:

```ts
shouldScrollHostScrollback(bufferType, shiftKey) =>
  shiftKey ? true : bufferType !== 'alternate'
```

## Mudanças

- `src/components/XTermView/terminalInput.ts` — novo helper `shouldScrollHostScrollback`.
- `src/components/XTermView/index.tsx` — `onWheel` agora repassa pra app no bverride do `Shift`.
- `tests/XTermView/terminalInput.test.ts` — 3 casos cobrindo shell, TUI e o override do `Shift`.

## Testes

- `npm test` — tudo passando (incluindo os casos novos).
- Manual, no app rodando (janela **e** maximizado):
  - Pane `claude`: wheel agora rola. ✅
  - PowerShell puro + `seq 1 500`: continua rolando o scrollback do host. ✅
  - `Shift`+wheel: força o scrollback do host em qualquer pane. ✅

## Observações

O comportamento de shells puros não muda. Sem dependências novas.