### PR TITLE
feat: auto-update in-app com o Tauri updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Assinatura do updater (minisign). Sem estes secrets o build FALHA,
+          # porque bundle.createUpdaterArtifacts está ligado. Gere o par com
+          # `npm run tauri signer generate` e cadastre nos secrets do repo.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: v__VERSION__
           releaseName: 'Alethe v__VERSION__'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alethe",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alethe",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
@@ -14,6 +14,8 @@
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-notification": "^2.3.3",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-webgl": "^0.18.0",
@@ -1844,6 +1846,24 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-webgl": "^0.18.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,13 +48,15 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tiny_http",
  "tokio",
  "urlencoding",
  "which",
  "windows-sys 0.61.2",
  "winreg 0.52.0",
- "zip",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -86,6 +88,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ascii"
@@ -789,6 +800,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2059,6 +2081,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,6 +2385,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2660,6 +2718,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,6 +2812,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3390,15 +3480,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3504,6 +3599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3619,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3543,6 +3677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3601,6 +3744,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3904,6 +4070,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,7 +4300,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4152,6 +4334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,7 +4367,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4348,6 +4541,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,7 +4593,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4380,7 +4616,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5265,6 +5501,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6051,7 +6296,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -6096,6 +6341,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6280,6 +6535,18 @@ dependencies = [
  "sha1",
  "time",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2.3.3"
+tauri-plugin-process = "2"
+tauri-plugin-updater = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "net"] }
 which = "6"
 zip = "0.6"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,6 +16,8 @@
     "core:window:allow-set-title",
     "core:webview:allow-set-webview-zoom",
     "dialog:default",
-    "notification:default"
+    "notification:default",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,8 @@ pub fn run() {
         .manage(discord_presence::DiscordPresence::new())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             #[cfg(debug_assertions)]
             if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,6 +27,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "publisher": "Kauã Miguel",
     "shortDescription": "Terminal multiplexer GUI",
@@ -38,5 +39,16 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "REPLACE_WITH_REAL_MINISIGN_PUBLIC_KEY",
+      "endpoints": [
+        "https://github.com/Kc1t/alethe-agents/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
+      }
+    }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { SyncModal } from './components/modals/SyncModal'
 import { SuspendGroupModal } from './components/modals/SuspendGroupModal'
 import { ThemePickerModal } from './components/modals/ThemePickerModal'
 import { TopbarSettingsModal } from './components/modals/TopbarSettingsModal'
+import { UpdateModal } from './components/modals/UpdateModal'
 import { WelcomeModal } from './components/modals/WelcomeModal'
 import { useKeybindings } from './hooks/useKeybindings'
 import { useDiscordPresence } from './hooks/useDiscordPresence'
@@ -31,6 +32,7 @@ import { startActivityTracker } from './lib/activityTracker'
 import { intlLocale, translate } from './lib/i18n'
 import { setMaxConcurrentSpawns } from './lib/spawnQueue'
 import { getLastCrashReport } from './lib/tauri'
+import { checkForUpdate } from './lib/updater'
 import { useProjectsStore } from './stores/projectsStore'
 import { type InAppToast, useUiStore } from './stores/uiStore'
 import styles from './App.module.css'
@@ -173,6 +175,22 @@ export default function App() {
     return startActivityTracker()
   }, [hydrated])
 
+  // Checa atualização em silêncio no boot. Se houver, o chip discreto na sidebar
+  // aparece (SidebarUpdate); nada de popup. Erros (dev sem assinatura, offline,
+  // endpoint fora) são engolidos — updater indisponível = "sem update".
+  useEffect(() => {
+    if (!hydrated) return
+    let cancelled = false
+    void checkForUpdate()
+      .then((info) => {
+        if (!cancelled) useUiStore.getState().setUpdateInfo(info)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [hydrated])
+
   // Se a sessão anterior não saiu limpa (crash/OOM/kill), avisa com o estado de
   // memória de quando caiu — diagnóstico de "o que matou o app".
   useEffect(() => {
@@ -245,6 +263,7 @@ export default function App() {
       ) : null}
       <ThemePickerModal />
       <TopbarSettingsModal />
+      <UpdateModal />
       </ErrorBoundary>
       <InAppNotifications />
       {activeView === 'agentCanvas' ? <TokenHud /> : null}

--- a/src/components/ProjectSidebar/SidebarUpdate.module.css
+++ b/src/components/ProjectSidebar/SidebarUpdate.module.css
@@ -1,0 +1,41 @@
+.chip {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: calc(100% - 16px);
+  margin: 0 8px 6px;
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.chip:hover {
+  background: var(--panel-hover);
+  color: var(--fg);
+  border-color: var(--accent-border);
+}
+
+.icon {
+  flex-shrink: 0;
+  color: var(--status-working);
+}
+
+.label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.version {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+  opacity: 0.85;
+}

--- a/src/components/ProjectSidebar/SidebarUpdate.tsx
+++ b/src/components/ProjectSidebar/SidebarUpdate.tsx
@@ -1,0 +1,31 @@
+import { ArrowUpCircle } from 'lucide-react'
+
+import { useUiStore } from '../../stores/uiStore'
+import { useT } from '../../lib/i18n'
+import styles from './SidebarUpdate.module.css'
+
+/**
+ * Aviso discreto de atualização no rodapé da sidebar. Fica invisível quando o
+ * app está atualizado (`updateInfo === null`, checado em silêncio no boot).
+ * Quando há versão nova, mostra um chip leve — clicar abre o modal de update.
+ */
+export function SidebarUpdate() {
+  const t = useT()
+  const info = useUiStore((s) => s.updateInfo)
+  const openModal = useUiStore((s) => s.openModal_)
+
+  if (!info) return null
+
+  return (
+    <button
+      type="button"
+      className={styles.chip}
+      onClick={() => openModal('updateAvailable')}
+      title={t('update.chipTitle', { version: info.version })}
+    >
+      <ArrowUpCircle size={13} className={styles.icon} />
+      <span className={styles.label}>{t('update.chipLabel')}</span>
+      <span className={styles.version}>{info.version}</span>
+    </button>
+  )
+}

--- a/src/components/ProjectSidebar/index.tsx
+++ b/src/components/ProjectSidebar/index.tsx
@@ -43,6 +43,7 @@ import { AgentIcon } from '../icons/AgentIcons'
 import { SidebarNowPlaying } from '../SidebarNowPlaying'
 import { UserProfile } from '../UserProfile'
 import { ContextMenu, type MenuItem } from './ContextMenu'
+import { SidebarUpdate } from './SidebarUpdate'
 import styles from './ProjectSidebar.module.css'
 
 const LAYOUTS: { id: LayoutMode; label: string; Icon: LucideIcon }[] = [
@@ -758,6 +759,7 @@ export function ProjectSidebar() {
       <WorkspaceLayoutFooter />
       <LayoutFooter />
       <SidebarNowPlaying />
+      <SidebarUpdate />
       <UserProfile />
     </aside>
   )

--- a/src/components/modals/UpdateModal.module.css
+++ b/src/components/modals/UpdateModal.module.css
@@ -1,0 +1,41 @@
+.summary {
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg);
+}
+
+.notes {
+  max-height: 220px;
+  overflow: auto;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  white-space: pre-wrap;
+}
+
+.progressTrack {
+  margin-top: 14px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--panel);
+  overflow: hidden;
+}
+
+.progressBar {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+
+.error {
+  margin: 10px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--status-offline);
+}

--- a/src/components/modals/UpdateModal.tsx
+++ b/src/components/modals/UpdateModal.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react'
+
+import { useUiStore } from '../../stores/uiStore'
+import { useT } from '../../lib/i18n'
+import { installPendingUpdate } from '../../lib/updater'
+import { Modal } from './Modal'
+import controls from './controls.module.css'
+import styles from './UpdateModal.module.css'
+
+export function UpdateModal() {
+  const t = useT()
+  const open = useUiStore((s) => s.openModal === 'updateAvailable')
+  const info = useUiStore((s) => s.updateInfo)
+  const closeModal = useUiStore((s) => s.closeModal)
+  const [phase, setPhase] = useState<'idle' | 'installing' | 'error'>('idle')
+  const [percent, setPercent] = useState(0)
+  const [error, setError] = useState('')
+
+  if (!open || !info) return null
+
+  const installing = phase === 'installing'
+
+  const onInstall = async () => {
+    setPhase('installing')
+    setError('')
+    try {
+      await installPendingUpdate(({ downloaded, total }) => {
+        setPercent(total > 0 ? Math.min(100, Math.round((downloaded / total) * 100)) : 0)
+      })
+      // relaunch() acontece dentro de installPendingUpdate; se voltar aqui, não reiniciou.
+    } catch (err) {
+      setPhase('error')
+      setError(String(err))
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      // Trava o fechar-por-fora enquanto instala pra não interromper o download.
+      onClose={installing ? () => {} : closeModal}
+      title={t('update.availableTitle', { version: info.version })}
+      footer={
+        <>
+          <button
+            type="button"
+            className={controls.btn}
+            onClick={closeModal}
+            disabled={installing}
+          >
+            {t('update.later')}
+          </button>
+          <button
+            type="button"
+            className={`${controls.btn} ${controls.btnPrimary}`}
+            onClick={() => void onInstall()}
+            disabled={installing}
+          >
+            {installing ? t('update.installing', { percent }) : t('update.installNow')}
+          </button>
+        </>
+      }
+    >
+      <p className={styles.summary}>
+        {t('update.body', { current: info.currentVersion, version: info.version })}
+      </p>
+      {info.notes ? <div className={styles.notes}>{info.notes}</div> : null}
+      {installing ? (
+        <div className={styles.progressTrack} aria-hidden>
+          <div className={styles.progressBar} style={{ width: `${percent}%` }} />
+        </div>
+      ) : null}
+      {phase === 'error' ? <p className={styles.error}>{t('update.error', { error })}</p> : null}
+    </Modal>
+  )
+}

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -760,6 +760,16 @@ export const en = {
   'crash.uncleanTitle': 'Alethe closed unexpectedly',
   'crash.uncleanBody': 'Last reading before it died: {total} MB · {procs} processes · {time}',
 
+  /* ---- app update ---- */
+  'update.chipLabel': 'Update available',
+  'update.chipTitle': 'Version {version} available — click to update',
+  'update.availableTitle': 'Update available — {version}',
+  'update.body': "You're on {current}. Version {version} is ready to install.",
+  'update.installNow': 'Update & restart',
+  'update.installing': 'Downloading… {percent}%',
+  'update.later': 'Later',
+  'update.error': 'Update failed: {error}',
+
   /* ---- data sync ---- */
   'sync.title': 'Sync your data',
   'sync.subtitle': 'Back up and restore your projects, layout and time stats.',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -760,6 +760,16 @@ export const ptBR: Record<MessageKey, string> = {
   'crash.uncleanTitle': 'O Alethe fechou sozinho',
   'crash.uncleanBody': 'Última leitura antes de cair: {total} MB · {procs} processos · {time}',
 
+  /* ---- app update ---- */
+  'update.chipLabel': 'Atualização disponível',
+  'update.chipTitle': 'Versão {version} disponível — clique para atualizar',
+  'update.availableTitle': 'Atualização disponível — {version}',
+  'update.body': 'Você está na {current}. A versão {version} está pronta para instalar.',
+  'update.installNow': 'Atualizar e reiniciar',
+  'update.installing': 'Baixando… {percent}%',
+  'update.later': 'Depois',
+  'update.error': 'Falha ao atualizar: {error}',
+
   /* ---- data sync ---- */
   'sync.title': 'Sincronizar seus dados',
   'sync.subtitle': 'Faça backup e restaure seus projetos, layout e estatísticas de tempo.',

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,0 +1,68 @@
+import { check, type Update } from '@tauri-apps/plugin-updater'
+import { relaunch } from '@tauri-apps/plugin-process'
+
+/** Metadados de um update disponível, prontos pra exibir na UI. */
+export type UpdateInfo = {
+  version: string
+  currentVersion: string
+  /** Release notes (corpo do `latest.json`), se houver. */
+  notes: string | null
+  /** Data de publicação (string do manifesto), se houver. */
+  date: string | null
+}
+
+export type UpdateProgress = { downloaded: number; total: number }
+
+/** Handle do update pendente. Fica no módulo (não no store) porque é um objeto
+ *  com métodos nativos — não dá pra serializar no Zustand nem no modalContext. */
+let pending: Update | null = null
+
+/**
+ * Consulta o endpoint configurado (`plugins.updater.endpoints`) por uma versão
+ * nova. Retorna `null` quando já está atualizado OU quando o updater não está
+ * configurado/acessível (dev sem assinatura, offline, etc.) — nesses casos
+ * `check()` lança e o chamador trata como "sem update", silenciosamente.
+ */
+export async function checkForUpdate(): Promise<UpdateInfo | null> {
+  const update = await check()
+  if (!update) {
+    pending = null
+    return null
+  }
+  pending = update
+  return {
+    version: update.version,
+    currentVersion: update.currentVersion,
+    notes: update.body ?? null,
+    date: update.date ?? null,
+  }
+}
+
+/**
+ * Baixa e instala o update pendente e reinicia o app. Requer um `checkForUpdate`
+ * prévio que tenha retornado um update. `onProgress` reporta bytes baixados.
+ */
+export async function installPendingUpdate(
+  onProgress?: (progress: UpdateProgress) => void,
+): Promise<void> {
+  if (!pending) throw new Error('Nenhum update pendente para instalar.')
+  let total = 0
+  let downloaded = 0
+  await pending.downloadAndInstall((event) => {
+    switch (event.event) {
+      case 'Started':
+        total = event.data.contentLength ?? 0
+        onProgress?.({ downloaded: 0, total })
+        break
+      case 'Progress':
+        downloaded += event.data.chunkLength
+        onProgress?.({ downloaded, total })
+        break
+      case 'Finished':
+        onProgress?.({ downloaded: total, total })
+        break
+    }
+  })
+  // Só chega aqui se o relaunch não tiver reiniciado o processo ainda.
+  await relaunch()
+}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { ClaudeUsage, CodexUsage, MemoryStats } from '../lib/tauri'
 import type { AgentType } from '../lib/types'
+import type { UpdateInfo } from '../lib/updater'
 
 /**
  * Estado de UI ephemeral — modais abertos, query do find/jump, drag em
@@ -26,6 +27,7 @@ type ModalKind =
   | 'profiles'
   | 'sync'
   | 'topbarSettings'
+  | 'updateAvailable'
   | null
 
 export type ActiveView = 'home' | 'workspace' | 'agentCanvas'
@@ -72,6 +74,8 @@ type UiState = {
   toasts: InAppToast[]
   /** Histórico recente de notificações (não some com o banner) — usado na Home. */
   notifications: InAppToast[]
+  /** Update disponível (checado em silêncio no boot). null = atualizado/sem info. */
+  updateInfo: UpdateInfo | null
 
   openModal_: (kind: Exclude<ModalKind, null>, context?: Record<string, unknown>) => void
   closeModal: () => void
@@ -98,6 +102,7 @@ type UiState = {
   }) => void
   dismissToast: (id: string) => void
   clearNotifications: () => void
+  setUpdateInfo: (info: UpdateInfo | null) => void
 }
 
 export const useUiStore = create<UiState>((set) => ({
@@ -118,6 +123,7 @@ export const useUiStore = create<UiState>((set) => ({
   agentCanvasBudgetUsd: null,
   toasts: [],
   notifications: [],
+  updateInfo: null,
 
   openModal_: (kind, context) => set({ openModal: kind, modalContext: context ?? null }),
   closeModal: () => set({ openModal: null, modalContext: null }),
@@ -159,4 +165,5 @@ export const useUiStore = create<UiState>((set) => ({
   dismissToast: (id) =>
     set((s) => ({ toasts: s.toasts.filter((toast) => toast.id !== id) })),
   clearNotifications: () => set({ notifications: [] }),
+  setUpdateInfo: (info) => set({ updateInfo: info }),
 }))


### PR DESCRIPTION
Fecha #15.

## Contexto

Distribuição hoje é manual — usuário descobre versão nova indo no GitHub. Este PR adiciona **auto-update in-app** com o plugin oficial do **Tauri 2**, com uma UX **discreta**: nada de popup no boot.

## Como funciona

- **Boot:** `checkForUpdate()` roda em silêncio. Sem update (ou updater indisponível em dev/offline) → nada aparece.
- **Sidebar:** havendo versão nova, um **chip leve no rodapé** (`SidebarUpdate`, tokens do DS) sinaliza.
- **Modal:** clicar no chip abre versão + release notes + barra de progresso → baixa → instala → `relaunch`.

## Mudanças

**Frontend**
- `lib/updater.ts` — wrapper `checkForUpdate` / `installPendingUpdate` (progresso + relaunch).
- `components/ProjectSidebar/SidebarUpdate.tsx` (+css) — chip discreto, só renderiza com update.
- `components/modals/UpdateModal.tsx` (+css) — detalhes/instalar/progresso.
- `uiStore` — `updateInfo` + modal `updateAvailable`; `App.tsx` checa no boot; i18n en/pt-BR (`update.*`).

**Backend/config**
- `Cargo.toml` + `lib.rs` — `tauri-plugin-updater` + `tauri-plugin-process`.
- `tauri.conf.json` — `createUpdaterArtifacts: true` + `plugins.updater` (endpoint `latest.json` do Kc1t, `installMode: passive`, **pubkey placeholder**).
- `capabilities/default.json` — `updater:default`, `process:allow-restart`.
- `release.yml` — env de assinatura no `tauri-action`.

## ⚠️ Ações necessárias do mantenedor (senão o build falha)

Como `createUpdaterArtifacts` está ligado, **o build passa a exigir a chave de assinatura**:

1. `npm run tauri signer generate -- -w ~/.tauri/alethe.key`
2. Secrets no repo: `TAURI_SIGNING_PRIVATE_KEY` e `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`.
3. Trocar `REPLACE_WITH_REAL_MINISIGN_PUBLIC_KEY` no `tauri.conf.json` pela pubkey (`.pub`).
4. Publicar uma release (baseline) — o `tauri-action` gera/assina o `latest.json`.

Obs: instalações antigas (sem updater) não se auto-atualizam pra baseline; dali em diante, automático.

## Verificação
- `tsc` + validação i18n ✅
- `cargo check` (310 crates) ✅
- `npm test` — 21/21 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pMAp5Qujov8VW8cpn94jD
