### PR TITLE
feat(cli): abrir projeto pelo terminal com `alethe` (closes #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Built with Tauri, Rust, React, TypeScript, Vite, `portable-pty`, and `xterm.js`.
 - Close containers without killing running processes.
 - Suspend groups to free memory.
 - Local backup export/import.
+- `alethe` terminal command to open any folder as a project.
 - Spotify Now Playing through the user's own Spotify app credentials.
 - Experimental agent planning canvas.
 - GitHub Actions release workflow for Windows, Linux, and macOS.
@@ -192,6 +193,25 @@ src-tauri/target/release/bundle/
 - Leave long-running terminals alive while changing layouts or closing visual containers.
 - Suspend inactive groups to free memory and restore them when the context is needed again.
 - Export a local backup before moving machines or testing risky changes.
+
+## Terminal Command
+
+Install the `alethe` command from **Settings ▸ Integrations ▸ Terminal command** to open a folder
+as a project without leaving the terminal:
+
+```bash
+alethe                # opens the current folder
+alethe .              # same
+alethe ~/some/project # opens the given folder
+```
+
+If the folder is already a project, Alethe brings it into the workspace instead of duplicating it.
+If it is not, the project is created with a terminal already pointing at that folder. When Alethe is
+already running, the existing window is focused rather than starting a second instance.
+
+The command is installed to `~/.local/bin/alethe` on macOS/Linux and to
+`%LOCALAPPDATA%\Alethe\bin\alethe.cmd` on Windows (added to the user `Path`). Reinstall it after
+moving or reinstalling the app — the settings screen flags a stale command.
 
 ## Spotify
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Mudanças relevantes do **Alethe** para quem usa o app. Formato inspirado em
 
 ### Adicionado
 
+- **Abrir projeto pelo terminal:** o comando `alethe` abre a pasta atual como projeto no Alethe — `alethe`, `alethe .` ou `alethe ~/algum/projeto`. Se a pasta já for um projeto, ele só é trazido pro workspace (sem duplicar); se não for, o projeto é criado com um terminal já apontando pra ela. Com o app aberto, a janela existente é focada em vez de subir uma segunda instância. Instale o comando em **Configurações ▸ Integrações ▸ Comando de terminal**.
 - Padrões de código documentados (`docs/CODE_STANDARDS.md`) e tooling de lint/format: referência única de estilo, estrutura de componentes, TypeScript, IPC, reuso de helpers, uso de `useEffect`/Zustand, i18n e checklist de PR, mais os comandos `npm run lint`/`npm run format` (ESLint flat + Prettier).
 - **Abrir arquivos no File Explorer:** clique duas vezes em qualquer arquivo na aba "File Explorer" da sidebar para abri-lo como pane no workspace.
 - **Visualizar diffs no Git Control:** clique duas vezes em um arquivo na seção "Changes" ou "Staged" do Git Control para abrir um diff pane monoespaçado no workspace com as alterações.

--- a/src-tauri/src/cli_launch.rs
+++ b/src-tauri/src/cli_launch.rs
@@ -1,0 +1,267 @@
+//! Abertura do Alethe pelo terminal — `alethe`, `alethe .`, `alethe <path>`.
+//!
+//! O fluxo tem dois caminhos, porque o app é single-instance:
+//!
+//! - **Cold start** (Alethe fechado): o diretório resolvido de `argv` fica
+//!   guardado em [`PendingOpen`]. O frontend consome uma única vez no boot via
+//!   `cli_take_pending_open` — não dá pra emitir evento aqui, a webview ainda
+//!   não existe.
+//! - **App já aberto**: o callback do `tauri-plugin-single-instance` recebe o
+//!   `argv`/`cwd` da segunda instância (que morre em seguida) e emite
+//!   [`OPEN_PATH_EVENT`] pra webview viva.
+//!
+//! A resolução só acontece quando há um caminho **explícito** no `argv`. Isso é
+//! deliberado: abrir por ícone (Finder/Explorer/menu) não passa caminho nenhum,
+//! e cair no `cwd` nesse caso criaria projeto de `/` ou `C:\Windows\system32`. O
+//! shim gerado em `cli_shim.rs` é quem transforma `alethe` sem argumento no
+//! `--open-path <pwd>` que chega aqui.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Evento que carrega o diretório pedido pelo terminal até o frontend.
+pub const OPEN_PATH_EVENT: &str = "alethe://open-path";
+
+/// Flag que o shim sempre passa. Aceitamos também `--open-path=<dir>` e um
+/// posicional solto (pra quem chama o binário na mão, sem shim).
+const OPEN_PATH_FLAG: &str = "--open-path";
+
+/// Diretório pedido no cold start, antes de existir webview pra receber evento.
+/// Consumido uma única vez (`take`) — reabrir a janela não repete a ação.
+#[derive(Default)]
+pub struct PendingOpen(Mutex<Option<String>>);
+
+/// Extrai o caminho cru do `argv`, ignorando `argv[0]` e qualquer outra flag.
+///
+/// Ignorar flags desconhecidas importa de verdade: o macOS injeta `-psn_0_1234`
+/// quando o app sobe pelo LaunchServices, e `tauri dev` passa flags próprias.
+/// Sem esse filtro, `-psn_0_1234` viraria "caminho" e a resolução falharia.
+fn extract_path_arg(args: &[String]) -> Option<String> {
+    let mut iter = args.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == OPEN_PATH_FLAG {
+            return iter.next().map(|value| value.to_string());
+        }
+        if let Some(value) = arg.strip_prefix(&format!("{OPEN_PATH_FLAG}=")) {
+            return Some(value.to_string());
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        return Some(arg.to_string());
+    }
+    None
+}
+
+/// Remove o prefixo verbatim (`\\?\`) que o `canonicalize` do Windows devolve.
+///
+/// O frontend compara esse caminho com o `defaultCwd` salvo dos projetos, e
+/// `\\?\C:\dev\app` nunca casaria com `C:\dev\app` — o projeto existente seria
+/// duplicado a cada `alethe .`.
+fn strip_verbatim_prefix(path: PathBuf) -> PathBuf {
+    let text = path.to_string_lossy();
+    // Pasta em rede vira `\\?\UNC\servidor\share`; tirar só o `\\?\` deixaria
+    // `UNC\servidor\share`, que não aponta pra lugar nenhum. O prefixo certo
+    // de volta é `\\`.
+    if let Some(stripped) = text.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{stripped}"));
+    }
+    match text.strip_prefix(r"\\?\") {
+        Some(stripped) => PathBuf::from(stripped),
+        None => path,
+    }
+}
+
+/// Canonicaliza e garante que o alvo é um diretório existente.
+///
+/// Apontar pra um arquivo (`alethe README.md`) abre a pasta que o contém, que é
+/// o que o usuário quis dizer — projeto no Alethe é sempre um diretório.
+fn normalize_dir(candidate: &Path) -> Option<PathBuf> {
+    let resolved = candidate
+        .canonicalize()
+        .map(strip_verbatim_prefix)
+        .unwrap_or_else(|_| candidate.to_path_buf());
+
+    if resolved.is_dir() {
+        return Some(resolved);
+    }
+    if resolved.is_file() {
+        return resolved.parent().map(|parent| parent.to_path_buf());
+    }
+    None
+}
+
+/// `argv` + `cwd` → diretório a abrir. `None` quando não há caminho explícito
+/// (abertura por ícone) ou quando o caminho passado não existe.
+pub fn resolve_target_dir(args: &[String], cwd: &Path) -> Option<PathBuf> {
+    let raw = extract_path_arg(args)?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = PathBuf::from(trimmed);
+    let candidate = if candidate.is_absolute() {
+        candidate
+    } else {
+        // `.`, `..` e relativos resolvem contra o cwd de QUEM chamou — no caso
+        // da segunda instância, o cwd vem do plugin, não do processo atual.
+        cwd.join(candidate)
+    };
+
+    normalize_dir(&candidate)
+}
+
+/// Lê o `argv` do próprio processo no boot e guarda o alvo pro frontend puxar.
+pub fn capture_cold_start(app: &AppHandle) {
+    let args: Vec<String> = std::env::args().collect();
+    let Ok(cwd) = std::env::current_dir() else {
+        return;
+    };
+    let Some(target) = resolve_target_dir(&args, &cwd) else {
+        return;
+    };
+    if let Ok(mut pending) = app.state::<PendingOpen>().0.lock() {
+        *pending = Some(target.to_string_lossy().to_string());
+    }
+}
+
+/// Callback da segunda instância: foca a janela viva e manda o diretório pra ela.
+pub fn handle_second_instance(app: &AppHandle, argv: Vec<String>, cwd: String) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+
+    let Some(target) = resolve_target_dir(&argv, Path::new(&cwd)) else {
+        return;
+    };
+    let _ = app.emit(OPEN_PATH_EVENT, target.to_string_lossy().to_string());
+}
+
+/// Consome (uma vez) o diretório pedido no cold start.
+#[tauri::command]
+pub fn cli_take_pending_open(state: tauri::State<'_, PendingOpen>) -> Option<String> {
+    state.0.lock().ok().and_then(|mut pending| pending.take())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|item| item.to_string()).collect()
+    }
+
+    #[test]
+    fn ignores_argv0_and_reads_flag() {
+        assert_eq!(
+            extract_path_arg(&args(&["alethe", "--open-path", "/tmp/x"])),
+            Some("/tmp/x".to_string())
+        );
+    }
+
+    #[test]
+    fn reads_inline_flag_form() {
+        assert_eq!(
+            extract_path_arg(&args(&["alethe", "--open-path=/tmp/x"])),
+            Some("/tmp/x".to_string())
+        );
+    }
+
+    #[test]
+    fn reads_bare_positional() {
+        assert_eq!(
+            extract_path_arg(&args(&["alethe", "/tmp/x"])),
+            Some("/tmp/x".to_string())
+        );
+    }
+
+    /// Regressão: o macOS injeta `-psn_0_1234` na abertura via LaunchServices.
+    #[test]
+    fn skips_unknown_flags_like_macos_psn() {
+        assert_eq!(extract_path_arg(&args(&["alethe", "-psn_0_1234"])), None);
+        assert_eq!(
+            extract_path_arg(&args(&["alethe", "-psn_0_1234", "/tmp/x"])),
+            Some("/tmp/x".to_string())
+        );
+    }
+
+    /// Abertura por ícone não passa caminho — não pode virar "abrir o cwd".
+    #[test]
+    fn no_args_means_no_target() {
+        assert_eq!(extract_path_arg(&args(&["alethe"])), None);
+        assert_eq!(resolve_target_dir(&args(&["alethe"]), Path::new("/")), None);
+    }
+
+    #[test]
+    fn dot_resolves_against_caller_cwd() {
+        let cwd = std::env::temp_dir().canonicalize().expect("temp dir");
+        let resolved = resolve_target_dir(&args(&["alethe", "."]), &cwd).expect("resolvido");
+        assert_eq!(resolved, cwd);
+    }
+
+    #[test]
+    fn relative_path_resolves_against_caller_cwd() {
+        let base = std::env::temp_dir().canonicalize().expect("temp dir");
+        let nested = base.join("alethe-cli-test-rel");
+        std::fs::create_dir_all(&nested).expect("criar dir");
+
+        let resolved =
+            resolve_target_dir(&args(&["alethe", "alethe-cli-test-rel"]), &base).expect("resolvido");
+        assert_eq!(resolved, nested);
+
+        let _ = std::fs::remove_dir_all(&nested);
+    }
+
+    #[test]
+    fn file_target_falls_back_to_its_directory() {
+        let base = std::env::temp_dir().canonicalize().expect("temp dir");
+        let dir = base.join("alethe-cli-test-file");
+        std::fs::create_dir_all(&dir).expect("criar dir");
+        let file = dir.join("README.md");
+        std::fs::write(&file, b"x").expect("escrever arquivo");
+
+        let resolved = resolve_target_dir(
+            &args(&["alethe", &file.to_string_lossy()]),
+            Path::new("/"),
+        )
+        .expect("resolvido");
+        assert_eq!(resolved, dir);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_path_resolves_to_none() {
+        let target = std::env::temp_dir().join("alethe-cli-test-inexistente-xyz");
+        let _ = std::fs::remove_dir_all(&target);
+        assert_eq!(
+            resolve_target_dir(&args(&["alethe", &target.to_string_lossy()]), Path::new("/")),
+            None
+        );
+    }
+
+    #[test]
+    fn strips_windows_verbatim_prefix() {
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\C:\dev\app")),
+            PathBuf::from(r"C:\dev\app")
+        );
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from("/home/u/app")),
+            PathBuf::from("/home/u/app")
+        );
+    }
+
+    /// Pasta em rede: `\\?\UNC\srv\share` tem que voltar pra `\\srv\share`.
+    #[test]
+    fn restores_unc_network_paths() {
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\UNC\servidor\share\app")),
+            PathBuf::from(r"\\servidor\share\app")
+        );
+    }
+}

--- a/src-tauri/src/cli_shim.rs
+++ b/src-tauri/src/cli_shim.rs
@@ -1,0 +1,470 @@
+//! Instalação do comando `alethe` no PATH do usuário.
+//!
+//! Equivalente ao "Install 'code' command in PATH" do VS Code: escreve um shim
+//! (script) que resolve o diretório alvo e chama o binário do app com
+//! `--open-path <dir>` (ver `cli_launch.rs`).
+//!
+//! O shim é quem faz o trabalho de resolver `alethe` sem argumento → `$PWD`.
+//! Assim o binário só abre projeto quando recebe caminho **explícito**, e subir
+//! o app pelo ícone continua caindo na Home normal.
+//!
+//! Onde o shim é escrito:
+//!
+//! | Plataforma      | Caminho                              | PATH                          |
+//! |-----------------|--------------------------------------|-------------------------------|
+//! | macOS / Linux   | `~/.local/bin/alethe`                | já costuma estar; só avisamos |
+//! | Windows         | `%LOCALAPPDATA%\Alethe\bin\alethe.cmd` | registrado em `HKCU\Environment` |
+//!
+//! Em Unix **não** mexemos em `.zshrc`/`.bashrc` nem pedimos sudo pra escrever
+//! em `/usr/local/bin`: instalar é uma ação explícita do usuário, mas nem por
+//! isso deve editar shell rc dele. Quando `~/.local/bin` não está no PATH, o
+//! status devolve `on_path: false` e a UI mostra a linha pra ele colar.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+#[cfg(windows)]
+const SHIM_FILE_NAME: &str = "alethe.cmd";
+#[cfg(not(windows))]
+const SHIM_FILE_NAME: &str = "alethe";
+
+/// Estado do comando de terminal, do jeito que a tela de Integrações precisa.
+#[derive(Serialize, Default)]
+pub struct CliShimStatus {
+    /// `false` em plataformas onde não sabemos instalar (mobile).
+    pub supported: bool,
+    pub installed: bool,
+    /// Shim instalado, mas apontando pra um binário que não é mais o atual —
+    /// acontece quando o app é movido/reinstalado. A UI oferece reinstalar.
+    pub stale: bool,
+    /// Caminho do shim (mesmo que ainda não exista) — mostrado na UI.
+    pub path: Option<String>,
+    pub bin_dir: Option<String>,
+    /// `bin_dir` está no PATH do processo atual.
+    pub on_path: bool,
+}
+
+/// Diretório onde o shim mora.
+fn shim_bin_dir() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    {
+        let base = dirs_next::data_local_dir()
+            .ok_or_else(|| "não foi possível resolver LOCALAPPDATA".to_string())?;
+        Ok(base.join("Alethe").join("bin"))
+    }
+    #[cfg(not(windows))]
+    {
+        let home =
+            dirs_next::home_dir().ok_or_else(|| "não foi possível resolver o HOME".to_string())?;
+        Ok(home.join(".local").join("bin"))
+    }
+}
+
+fn shim_path() -> Result<PathBuf, String> {
+    Ok(shim_bin_dir()?.join(SHIM_FILE_NAME))
+}
+
+/// Binário do Alethe que o shim deve chamar.
+fn current_binary() -> Result<PathBuf, String> {
+    std::env::current_exe().map_err(|error| error.to_string())
+}
+
+/// Bundle `.app` que contém o binário (só macOS). Preferimos chamar `open -na`
+/// no bundle a executar o binário direto: o `open` volta na hora (não prende o
+/// terminal) e deixa o LaunchServices ativar a janela.
+#[cfg(target_os = "macos")]
+fn app_bundle(binary: &Path) -> Option<PathBuf> {
+    binary
+        .ancestors()
+        .find(|ancestor| ancestor.extension().and_then(|ext| ext.to_str()) == Some("app"))
+        .map(|bundle| bundle.to_path_buf())
+}
+
+/// `bin_dir` aparece no PATH do processo? Usado só pra avisar o usuário.
+fn dir_on_path(dir: &Path) -> bool {
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path_var).any(|entry| entry == dir)
+}
+
+/// Escapa um caminho pra dentro de aspas simples de `sh`.
+#[cfg(not(windows))]
+fn sh_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+/// Conteúdo do shim POSIX. `launch` é a linha que efetivamente sobe o app.
+#[cfg(not(windows))]
+fn unix_shim_script(target_marker: &str, launch: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+# alethe — abre um diretório no Alethe a partir do terminal.
+#
+# Gerado automaticamente pelo Alethe (Configurações ▸ Integrações ▸ Comando de
+# terminal). Não edite à mão: reinstale por lá, principalmente depois de mover
+# ou reinstalar o app.
+#
+# alethe            → abre o diretório atual
+# alethe .          → idem
+# alethe ~/projeto  → abre o diretório informado
+#
+# ALETHE_TARGET_BIN: {target_marker}
+
+set -e
+
+target=${{1:-.}}
+
+if [ ! -d "$target" ]; then
+  echo "alethe: diretório não encontrado: $target" >&2
+  exit 1
+fi
+
+# Caminho absoluto: o app compara com o cwd salvo dos projetos.
+target=$(cd "$target" && pwd)
+
+{launch}
+"#
+    )
+}
+
+/// Gera o script/`.cmd` do shim pro binário informado.
+fn render_shim(binary: &Path) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        // Bundle quando existe (build empacotado); binário direto em `tauri dev`.
+        if let Some(bundle) = app_bundle(binary) {
+            let quoted = sh_single_quote(&bundle.to_string_lossy());
+            return Ok(unix_shim_script(
+                &bundle.to_string_lossy(),
+                &format!("exec open -na {quoted} --args --open-path \"$target\""),
+            ));
+        }
+        let quoted = sh_single_quote(&binary.to_string_lossy());
+        return Ok(unix_shim_script(
+            &binary.to_string_lossy(),
+            &format!(
+                "nohup {quoted} --open-path \"$target\" >/dev/null 2>&1 &\n\
+                 exit 0"
+            ),
+        ));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let quoted = sh_single_quote(&binary.to_string_lossy());
+        return Ok(unix_shim_script(
+            &binary.to_string_lossy(),
+            // Desanexado: sem isso, fechar o terminal derrubaria o app junto.
+            &format!(
+                "nohup {quoted} --open-path \"$target\" >/dev/null 2>&1 &\n\
+                 exit 0"
+            ),
+        ));
+    }
+
+    #[cfg(windows)]
+    {
+        let binary = binary.to_string_lossy().to_string();
+        return Ok(format!(
+            r#"@echo off
+rem alethe - abre um diretorio no Alethe a partir do terminal.
+rem
+rem Gerado automaticamente pelo Alethe (Configuracoes > Integracoes > Comando de
+rem terminal). Nao edite a mao: reinstale por la, principalmente depois de mover
+rem ou reinstalar o app.
+rem
+rem ALETHE_TARGET_BIN: {binary}
+
+setlocal
+set "target=%~1"
+if "%target%"=="" set "target=%CD%"
+
+rem Caminho absoluto: o app compara com o cwd salvo dos projetos.
+for %%I in ("%target%") do set "target=%%~fI"
+
+if not exist "%target%\" (
+  echo alethe: diretorio nao encontrado: %target% 1>&2
+  exit /b 1
+)
+
+start "" "{binary}" --open-path "%target%"
+"#
+        ));
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = binary;
+        Err("plataforma sem suporte a comando de terminal".to_string())
+    }
+}
+
+/// Marca `ALETHE_TARGET_BIN:` gravada no shim — é como detectamos shim obsoleto
+/// sem precisar reparsear o script inteiro.
+fn shim_targets_binary(contents: &str, binary: &Path) -> bool {
+    let Some(line) = contents
+        .lines()
+        .find_map(|line| line.split_once("ALETHE_TARGET_BIN:"))
+        .map(|(_, rest)| rest.trim())
+    else {
+        return false;
+    };
+    #[cfg(target_os = "macos")]
+    if let Some(bundle) = app_bundle(binary) {
+        return line == bundle.to_string_lossy();
+    }
+    line == binary.to_string_lossy()
+}
+
+fn build_status() -> Result<CliShimStatus, String> {
+    let bin_dir = shim_bin_dir()?;
+    let path = shim_path()?;
+    let binary = current_binary()?;
+
+    let contents = std::fs::read_to_string(&path).ok();
+    let installed = contents.is_some();
+    let stale = contents
+        .map(|contents| !shim_targets_binary(&contents, &binary))
+        .unwrap_or(false);
+
+    Ok(CliShimStatus {
+        supported: cfg!(any(unix, windows)),
+        installed,
+        stale,
+        path: Some(path.to_string_lossy().to_string()),
+        bin_dir: Some(bin_dir.to_string_lossy().to_string()),
+        on_path: dir_on_path(&bin_dir),
+    })
+}
+
+#[tauri::command]
+pub fn cli_shim_status() -> Result<CliShimStatus, String> {
+    build_status()
+}
+
+#[tauri::command]
+pub fn cli_shim_install() -> Result<CliShimStatus, String> {
+    let bin_dir = shim_bin_dir()?;
+    let path = shim_path()?;
+    let binary = current_binary()?;
+
+    std::fs::create_dir_all(&bin_dir).map_err(|error| error.to_string())?;
+    std::fs::write(&path, render_shim(&binary)?).map_err(|error| error.to_string())?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .map_err(|error| error.to_string())?;
+    }
+
+    // Só o Windows precisa de registro: `~/.local/bin` já é convenção no PATH
+    // das distros e do macOS, e editar rc de shell do usuário é invasivo demais.
+    #[cfg(windows)]
+    windows_path::add_to_user_path(&bin_dir)?;
+
+    build_status()
+}
+
+#[tauri::command]
+pub fn cli_shim_uninstall() -> Result<CliShimStatus, String> {
+    let path = shim_path()?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.to_string()),
+    }
+
+    #[cfg(windows)]
+    windows_path::remove_from_user_path(&shim_bin_dir()?)?;
+
+    build_status()
+}
+
+/// PATH do usuário no registro (`HKCU\Environment`).
+///
+/// Cuidado central aqui: **preservar o tipo do valor**. Se o PATH do usuário é
+/// `REG_EXPAND_SZ` (comum, com entradas tipo `%USERPROFILE%\bin`) e a gente
+/// reescreve como `REG_SZ`, todas as variáveis param de expandir — PATH
+/// quebrado pro usuário inteiro. Por isso lemos o valor cru e devolvemos com o
+/// mesmo `vtype`.
+#[cfg(windows)]
+mod windows_path {
+    use std::path::Path;
+
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
+    use winreg::types::FromRegValue;
+    use winreg::{RegKey, RegValue};
+
+    fn open_environment() -> Result<RegKey, String> {
+        RegKey::predef(HKEY_CURRENT_USER)
+            .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
+            .map_err(|error| error.to_string())
+    }
+
+    /// Devolve o PATH atual **junto do seu `RegType`**, pra devolver do mesmo
+    /// jeito depois. `REG_EXPAND_SZ` é o default quando o valor nem existe.
+    fn read_path(key: &RegKey) -> (String, RegType) {
+        match key.get_raw_value("Path") {
+            Ok(value) => {
+                let vtype = value.vtype.clone();
+                let text = String::from_reg_value(&value).unwrap_or_default();
+                (text, vtype)
+            }
+            Err(_) => (String::new(), RegType::REG_EXPAND_SZ),
+        }
+    }
+
+    fn write_path(key: &RegKey, value: &str, vtype: RegType) -> Result<(), String> {
+        let mut bytes: Vec<u8> = value
+            .encode_utf16()
+            .flat_map(|unit| unit.to_ne_bytes())
+            .collect();
+        // Terminador UTF-16 — o registro guarda string larga com NUL final.
+        bytes.extend_from_slice(&[0, 0]);
+        key.set_raw_value("Path", &RegValue { bytes, vtype })
+            .map_err(|error| error.to_string())
+    }
+
+    fn entries(path: &str) -> Vec<&str> {
+        path.split(';').filter(|entry| !entry.trim().is_empty()).collect()
+    }
+
+    pub fn add_to_user_path(dir: &Path) -> Result<(), String> {
+        let key = open_environment()?;
+        let (current, vtype) = read_path(&key);
+        let target = dir.to_string_lossy().to_string();
+
+        if entries(&current)
+            .iter()
+            .any(|entry| entry.trim_end_matches('\\').eq_ignore_ascii_case(target.trim_end_matches('\\')))
+        {
+            return Ok(());
+        }
+
+        let updated = if current.trim().is_empty() {
+            target
+        } else {
+            format!("{};{}", current.trim_end_matches(';'), target)
+        };
+        write_path(&key, &updated, vtype)?;
+        broadcast_environment_change();
+        Ok(())
+    }
+
+    pub fn remove_from_user_path(dir: &Path) -> Result<(), String> {
+        let key = open_environment()?;
+        let (current, vtype) = read_path(&key);
+        let target = dir.to_string_lossy().to_string();
+        let target = target.trim_end_matches('\\');
+
+        let all = entries(&current);
+        let kept: Vec<&str> = all
+            .iter()
+            .copied()
+            .filter(|entry| !entry.trim_end_matches('\\').eq_ignore_ascii_case(target))
+            .collect();
+
+        if kept.len() == all.len() {
+            return Ok(());
+        }
+        write_path(&key, &kept.join(";"), vtype)?;
+        broadcast_environment_change();
+        Ok(())
+    }
+
+    /// Avisa o shell/Explorer que o ambiente mudou — sem isso, o usuário só vê
+    /// o comando aparecer depois de deslogar.
+    fn broadcast_environment_change() {
+        use windows_sys::Win32::Foundation::{HWND, LPARAM, WPARAM};
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            SendMessageTimeoutW, HWND_BROADCAST, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE,
+        };
+
+        let param: Vec<u16> = "Environment\0".encode_utf16().collect();
+        unsafe {
+            SendMessageTimeoutW(
+                HWND_BROADCAST as HWND,
+                WM_SETTINGCHANGE,
+                0 as WPARAM,
+                param.as_ptr() as LPARAM,
+                SMTO_ABORTIFHUNG,
+                5000,
+                std::ptr::null_mut(),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shim_mentions_target_binary() {
+        let binary = PathBuf::from("/opt/alethe/alethe");
+        let script = render_shim(&binary).expect("script");
+        assert!(shim_targets_binary(&script, &binary));
+    }
+
+    #[test]
+    fn stale_shim_is_detected() {
+        let old = PathBuf::from("/opt/alethe-antigo/alethe");
+        let script = render_shim(&old).expect("script");
+        assert!(!shim_targets_binary(&script, Path::new("/opt/alethe-novo/alethe")));
+    }
+
+    #[test]
+    fn shim_without_marker_counts_as_stale() {
+        assert!(!shim_targets_binary("#!/bin/sh\necho oi\n", Path::new("/opt/alethe/alethe")));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn shim_defaults_to_current_dir_and_is_a_posix_script() {
+        let script = render_shim(Path::new("/opt/alethe/alethe")).expect("script");
+        assert!(script.starts_with("#!/bin/sh"));
+        // `alethe` sem argumento tem que virar "." e depois virar caminho absoluto.
+        assert!(script.contains("target=${1:-.}"));
+        assert!(script.contains("--open-path"));
+    }
+
+    /// O shim é código gerado: um erro de sintaxe só apareceria pro usuário na
+    /// hora de rodar `alethe`. `sh -n` faz o parse sem executar nada.
+    #[cfg(not(windows))]
+    #[test]
+    fn generated_shim_is_valid_shell_syntax() {
+        use std::io::Write;
+        use std::process::Command;
+
+        for binary in ["/opt/alethe/alethe", "/Applications/Alethe.app/Contents/MacOS/Alethe"] {
+            let script = render_shim(Path::new(binary)).expect("script");
+            let file = std::env::temp_dir().join(format!(
+                "alethe-shim-syntax-{}.sh",
+                binary.replace(['/', '.'], "_")
+            ));
+            std::fs::File::create(&file)
+                .and_then(|mut handle| handle.write_all(script.as_bytes()))
+                .expect("escrever shim");
+
+            let output = Command::new("sh").arg("-n").arg(&file).output().expect("rodar sh -n");
+            let _ = std::fs::remove_file(&file);
+
+            assert!(
+                output.status.success(),
+                "shim inválido para {binary}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn single_quotes_in_path_are_escaped() {
+        let script = render_shim(Path::new("/opt/alethe's app/alethe")).expect("script");
+        // Sem escape, a aspa fecharia a string e o shim viraria sintaxe inválida.
+        assert!(script.contains(r"'\''"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,9 @@ mod antigravity_usage;
 mod backup;
 mod claude_sessions;
 mod claude_usage;
+mod cli_launch;
 mod cli_resolver;
+mod cli_shim;
 mod codex_sessions;
 mod codex_usage;
 mod crash_watch;
@@ -120,6 +122,7 @@ pub fn run() {
         .manage(filesystem::FileWatchers::default())
         .manage(discord_presence::DiscordPresence::new())
         .manage(planning::PlanningWatchers::default())
+        .manage(cli_launch::PendingOpen::default())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_process::init())
@@ -129,14 +132,13 @@ pub fn run() {
     // monotonicidade de `save_projects` (projects.rs): duas instâncias teriam
     // cada uma seu próprio LAST_WRITE_SEQUENCE em memória, e a garantia de
     // last-write-wins deixaria de valer entre processos. Segunda instância só
-    // foca a janela existente em vez de abrir outra.
+    // foca a janela existente em vez de abrir outra — e, quando veio de
+    // `alethe <path>` no terminal, entrega o diretório pedido pra ela (ver
+    // cli_launch.rs) antes de morrer.
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.unminimize();
-                let _ = window.set_focus();
-            }
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+            cli_launch::handle_second_instance(app, argv, cwd);
         }));
     }
 
@@ -147,6 +149,9 @@ pub fn run() {
                 let _ = window.set_title("(DEV) Alethe");
             }
             logging::set_logs_dir(app.handle());
+            // `alethe <path>` com o app fechado: guarda o alvo agora, o
+            // frontend consome no boot (a webview ainda não existe aqui).
+            cli_launch::capture_cold_start(app.handle());
             // Cantos arredondados no macOS (no-op nas outras plataformas). A
             // janela roda sem decorações nativas, então reaplicamos o
             // arredondamento no nível do AppKit.
@@ -225,6 +230,10 @@ pub fn run() {
             profiles::rename_profile,
             profiles::delete_profile,
             cli_resolver::find_cli_launcher,
+            cli_launch::cli_take_pending_open,
+            cli_shim::cli_shim_status,
+            cli_shim::cli_shim_install,
+            cli_shim::cli_shim_uninstall,
             backup::export_backup,
             backup::export_profile_backup,
             backup::import_backup,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { WhatsNewModal } from './components/modals/WhatsNewModal'
 import { WelcomeModal } from './components/modals/WelcomeModal'
 import { useKeybindings } from './hooks/useKeybindings'
 import { useDiscordPresence } from './hooks/useDiscordPresence'
+import { useCliOpenRequests } from './hooks/useCliOpenRequests'
 import { useCloseConfirmation } from './hooks/useCloseConfirmation'
 import { useResourceSupervisor } from './hooks/useResourceSupervisor'
 import { startActivityTracker } from './lib/activityTracker'
@@ -198,6 +199,7 @@ export default function App() {
   useDiscordPresence()
   useCloseConfirmation()
   useResourceSupervisor(hydrated)
+  useCliOpenRequests(hydrated)
 
   useEffect(() => {
     void hydrate()

--- a/src/components/modals/PreferencesModal.module.css
+++ b/src/components/modals/PreferencesModal.module.css
@@ -570,6 +570,32 @@
   font-size: 10px;
   line-height: 1.5;
 }
+/* Comando de terminal (`alethe`) — bloco de uso + ações de instalar/remover. */
+.cliUsage {
+  margin: 0;
+  padding: 10px 12px;
+  overflow-x: auto;
+  color: var(--fg-muted);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.7;
+}
+.cliActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.integrationFields p.cliPath {
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+.integrationFields p.cliWarning {
+  color: var(--status-waiting);
+}
+
 .segmented {
   display: inline-flex;
   padding: 3px;

--- a/src/components/modals/PreferencesModal.tsx
+++ b/src/components/modals/PreferencesModal.tsx
@@ -204,6 +204,13 @@ export function PreferencesModal() {
       },
       {
         category: 'integrations',
+        target: 'terminal-command',
+        label: t('prefs.cliCommand'),
+        description: t('prefs.cliCommandDesc'),
+        keywords: 'cli command terminal path shell comando linha de comando abrir pasta',
+      },
+      {
+        category: 'integrations',
         target: 'spotify',
         label: t('prefs.spotify'),
         description: t('prefs.spotifyDesc'),

--- a/src/components/modals/preferences/IntegrationsPage.tsx
+++ b/src/components/modals/preferences/IntegrationsPage.tsx
@@ -1,8 +1,107 @@
+import { useEffect, useState } from 'react'
+
 import { useT } from '../../../lib/i18n'
+import {
+  cliShimInstall,
+  type CliShimStatus,
+  cliShimStatus,
+  cliShimUninstall,
+} from '../../../lib/tauri'
 import { useProjectsStore } from '../../../stores/projectsStore'
 import controls from '../controls.module.css'
 import styles from '../PreferencesModal.module.css'
 import { SettingsSection } from './primitives'
+
+/**
+ * Instalação do comando `alethe` no PATH (ver `src-tauri/src/cli_shim.rs`).
+ * Espelha o "Install 'code' command in PATH" do VS Code: instalar é sempre
+ * ação explícita do usuário, nunca automática no boot.
+ */
+function TerminalCommandSection() {
+  const t = useT()
+  const [status, setStatus] = useState<CliShimStatus | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let disposed = false
+    void cliShimStatus()
+      .then((next) => {
+        if (!disposed) setStatus(next)
+      })
+      .catch(() => {
+        if (!disposed) setStatus(null)
+      })
+    return () => {
+      disposed = true
+    }
+  }, [])
+
+  const run = async (action: () => Promise<CliShimStatus>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      setStatus(await action())
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <SettingsSection
+      id="terminal-command"
+      title={t('prefs.cliCommand')}
+      description={t('prefs.cliCommandDesc')}
+    >
+      <div className={styles.integrationFields}>
+        <pre className={styles.cliUsage}>
+          <code>{'alethe\nalethe .\nalethe ~/meu-projeto'}</code>
+        </pre>
+
+        {status?.supported === false ? (
+          <p>{t('prefs.cliUnsupported')}</p>
+        ) : (
+          <>
+            <div className={styles.cliActions}>
+              <button
+                type="button"
+                className={`${controls.btn} ${controls.btnPrimary}`}
+                disabled={busy || !status}
+                onClick={() => void run(cliShimInstall)}
+              >
+                {status?.installed ? t('prefs.cliReinstall') : t('prefs.cliInstall')}
+              </button>
+              {status?.installed ? (
+                <button
+                  type="button"
+                  className={`${controls.btn} ${controls.btnDanger}`}
+                  disabled={busy}
+                  onClick={() => void run(cliShimUninstall)}
+                >
+                  {t('prefs.cliUninstall')}
+                </button>
+              ) : null}
+            </div>
+
+            {status?.installed && status.path ? (
+              <p className={styles.cliPath}>{t('prefs.cliInstalledAt', { path: status.path })}</p>
+            ) : null}
+
+            {status?.stale ? <p className={styles.cliWarning}>{t('prefs.cliStale')}</p> : null}
+
+            {status?.installed && !status.onPath && status.binDir ? (
+              <p className={styles.cliWarning}>{t('prefs.cliNotOnPath', { dir: status.binDir })}</p>
+            ) : null}
+
+            {error ? <p className={styles.cliWarning}>{error}</p> : null}
+          </>
+        )}
+      </div>
+    </SettingsSection>
+  )
+}
 
 export function IntegrationsPage() {
   const t = useT()
@@ -10,6 +109,8 @@ export function IntegrationsPage() {
   const setPreferences = useProjectsStore((state) => state.setPreferences)
   return (
     <>
+      <TerminalCommandSection />
+
       <SettingsSection id="spotify" title={t('prefs.spotify')} description={t('prefs.spotifyDesc')}>
         <div className={styles.integrationFields}>
           <label>

--- a/src/hooks/useCliOpenRequests.ts
+++ b/src/hooks/useCliOpenRequests.ts
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+
+import { planCliOpen } from '../lib/cliOpen'
+import { useT } from '../lib/i18n'
+import { cliTakePendingOpen, listenCliOpenPath } from '../lib/tauri'
+import type { AgentType } from '../lib/types'
+import { useProjectsStore } from '../stores/projectsStore'
+import { useUiStore } from '../stores/uiStore'
+
+/**
+ * Abre no workspace o diretório pedido pelo terminal (`alethe`, `alethe .`,
+ * `alethe <path>` — ver `src-tauri/src/cli_launch.rs`).
+ *
+ * Duas origens, mesma ação:
+ * - cold start → `cliTakePendingOpen()` (o backend entrega uma vez só);
+ * - app já aberto → evento da segunda instância.
+ */
+
+/** Ordem de preferência do agente do primeiro terminal; cai em `shell`. */
+const AGENT_PREFERENCE: AgentType[] = ['claude', 'codex', 'antigravity', 'opencode', 'shell']
+
+const AGENT_LABEL: Record<AgentType, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  antigravity: 'Antigravity',
+  opencode: 'OpenCode',
+  shell: 'Shell',
+  mimo: 'Mimo',
+  freebuff: 'Freebuff',
+}
+
+export function useCliOpenRequests(hydrated: boolean) {
+  const t = useT()
+
+  useEffect(() => {
+    // Só depois da hidratação: agir antes de `projects.json` carregar faria
+    // `planCliOpen` não achar o projeto existente e duplicar a pasta.
+    if (!hydrated) return
+    let disposed = false
+
+    const openFromCli = (path: string) => {
+      const store = useProjectsStore.getState()
+      const plan = planCliOpen(path, store.projects)
+      if (!plan) return
+
+      if (plan.kind === 'existing') {
+        store.openProjectWorkspace(plan.projectId)
+        return
+      }
+
+      const project = store.createProject({ name: plan.name, defaultCwd: plan.cwd })
+      const agent =
+        AGENT_PREFERENCE.find((candidate) => store.preferences.enabledAgents[candidate]) ?? 'shell'
+      const terminal = store.createTerminal(project.id, {
+        name: AGENT_LABEL[agent],
+        cwd: plan.cwd,
+        firstTab: { type: agent, cwd: plan.cwd, runtimeProfile: 'lean' },
+      })
+      store.openTerminalWorkspace(project.id, terminal.id)
+      useUiStore.getState().pushToast({ title: t('notif.cliProjectCreated'), body: plan.name })
+    }
+
+    // Reexecutar este efeito (troca de idioma) é seguro: o backend já consumiu
+    // o pendente e devolve `null` daqui em diante.
+    void cliTakePendingOpen()
+      .then((path) => {
+        if (!disposed && path) openFromCli(path)
+      })
+      .catch(() => {
+        /* best-effort: sem CLI o app abre normal */
+      })
+
+    const unlisten = listenCliOpenPath((path) => {
+      if (!disposed) openFromCli(path)
+    })
+
+    return () => {
+      disposed = true
+      void unlisten.then((stop) => stop())
+    }
+  }, [hydrated, t])
+}

--- a/src/lib/cliOpen.test.ts
+++ b/src/lib/cliOpen.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { planCliOpen } from './cliOpen'
+import type { Project } from './types'
+
+function project(id: string, defaultCwd?: string): Project {
+  return {
+    id,
+    name: id,
+    groupId: null,
+    terminals: [],
+    layoutMode: 'auto',
+    collapsed: false,
+    createdAt: 0,
+    ...(defaultCwd ? { defaultCwd } : {}),
+  }
+}
+
+describe('planCliOpen', () => {
+  it('cria projeto quando nenhuma pasta bate', () => {
+    expect(planCliOpen('/home/u/novo', [project('a', '/home/u/outro')])).toEqual({
+      kind: 'create',
+      name: 'novo',
+      cwd: '/home/u/novo',
+    })
+  })
+
+  it('reaproveita o projeto existente da mesma pasta', () => {
+    expect(
+      planCliOpen('/home/u/app', [project('a', '/home/u/outro'), project('b', '/home/u/app')]),
+    ).toEqual({ kind: 'existing', projectId: 'b' })
+  })
+
+  it('ignora projetos sem defaultCwd', () => {
+    expect(planCliOpen('/home/u/app', [project('sem-pasta')])).toEqual({
+      kind: 'create',
+      name: 'app',
+      cwd: '/home/u/app',
+    })
+  })
+
+  // Regressão do bug mais provável da feature: sem normalização, cada `alethe .`
+  // no Windows criaria um projeto novo pra mesma pasta.
+  it('casa a pasta no Windows ignorando caixa e separador', () => {
+    expect(planCliOpen('C:/Users/Deb/App', [project('a', 'C:\\Users\\deb\\app')])).toEqual({
+      kind: 'existing',
+      projectId: 'a',
+    })
+  })
+
+  it('não confunde caixa diferente em caminho POSIX (case-sensitive)', () => {
+    expect(planCliOpen('/home/u/App', [project('a', '/home/u/app')])).toEqual({
+      kind: 'create',
+      name: 'App',
+      cwd: '/home/u/App',
+    })
+  })
+
+  it('ignora barra final ao comparar', () => {
+    expect(planCliOpen('/home/u/app/', [project('a', '/home/u/app')])).toEqual({
+      kind: 'existing',
+      projectId: 'a',
+    })
+  })
+
+  it('nomeia o projeto com a última pasta do caminho', () => {
+    expect(planCliOpen('C:\\dev\\meu-projeto', [])).toEqual({
+      kind: 'create',
+      name: 'meu-projeto',
+      cwd: 'C:\\dev\\meu-projeto',
+    })
+  })
+
+  it('devolve null pra caminho vazio', () => {
+    expect(planCliOpen('   ', [])).toBeNull()
+  })
+})

--- a/src/lib/cliOpen.ts
+++ b/src/lib/cliOpen.ts
@@ -1,0 +1,32 @@
+/**
+ * Decide o que fazer com um diretório vindo do terminal (`alethe <path>`).
+ *
+ * Separado do hook de propósito: a regra "já existe projeto nessa pasta?" é o
+ * miolo da feature e vale testar sem React nem IPC no meio.
+ */
+
+import { basename, sameCwd } from './paths'
+import type { Project } from './types'
+
+export type CliOpenPlan =
+  /** Já existe projeto apontando pra essa pasta — só trazer pro workspace. */
+  | { kind: 'existing'; projectId: string }
+  /** Pasta nova — criar projeto com o nome dela. */
+  | { kind: 'create'; name: string; cwd: string }
+
+/**
+ * `null` quando não há o que fazer (caminho vazio). A comparação usa `sameCwd`,
+ * que normaliza separador e caixa só quando o caminho é claramente do Windows —
+ * sem isso, `alethe .` duplicaria o projeto a cada chamada.
+ */
+export function planCliOpen(path: string, projects: Project[]): CliOpenPlan | null {
+  const cwd = path.trim()
+  if (!cwd) return null
+
+  const existing = projects.find(
+    (project) => project.defaultCwd && sameCwd(project.defaultCwd, cwd),
+  )
+  if (existing) return { kind: 'existing', projectId: existing.id }
+
+  return { kind: 'create', name: basename(cwd) || cwd, cwd }
+}

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -335,6 +335,18 @@ export const en = {
   'prefs.resetSessionEmpty': 'No agents to resume',
   'prefs.resetSessionEmptyBody': 'No open agent panes (Claude/Codex/OpenCode) were found.',
   'prefs.resetSessionFailed': 'Could not resume the last session.',
+  'prefs.cliCommand': 'Terminal command',
+  'prefs.cliCommandDesc':
+    "Install the 'alethe' command so you can open any folder as a project straight from the terminal.",
+  'prefs.cliInstall': 'Install command',
+  'prefs.cliReinstall': 'Reinstall command',
+  'prefs.cliUninstall': 'Remove',
+  'prefs.cliInstalledAt': 'Installed at {path}',
+  'prefs.cliStale':
+    'The installed command points to an older copy of Alethe. Reinstall it to update the path.',
+  'prefs.cliNotOnPath':
+    '{dir} is not in your PATH. Add it to your shell profile: export PATH="{dir}:$PATH"',
+  'prefs.cliUnsupported': 'The terminal command is not available on this platform.',
   'prefs.spotify': 'Spotify',
   'prefs.spotifyDesc': 'Configure the Spotify application used by the Now Playing widget.',
   'prefs.discordPresence': 'Discord Rich Presence',
@@ -1149,6 +1161,7 @@ export const en = {
   'notif.responded': '{label} responded.',
   'notif.responseReadyInPath': 'Response ready in {path}.',
   'notif.responseReady': 'Response ready.',
+  'notif.cliProjectCreated': 'Project created from the terminal',
   'notif.limitResetTitle': 'Limit reset',
   'notif.limitResetBody': '{agent} — {window} limit is available again',
 

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -336,6 +336,18 @@ export const ptBR: Record<MessageKey, string> = {
   'prefs.resetSessionEmptyBody':
     'Nenhum painel de agente aberto (Claude/Codex/OpenCode) foi encontrado.',
   'prefs.resetSessionFailed': 'Não deu pra retomar a última sessão.',
+  'prefs.cliCommand': 'Comando de terminal',
+  'prefs.cliCommandDesc':
+    "Instale o comando 'alethe' pra abrir qualquer pasta como projeto direto do terminal.",
+  'prefs.cliInstall': 'Instalar comando',
+  'prefs.cliReinstall': 'Reinstalar comando',
+  'prefs.cliUninstall': 'Remover',
+  'prefs.cliInstalledAt': 'Instalado em {path}',
+  'prefs.cliStale':
+    'O comando instalado aponta pra uma cópia antiga do Alethe. Reinstale pra atualizar o caminho.',
+  'prefs.cliNotOnPath':
+    '{dir} não está no seu PATH. Adicione no perfil do shell: export PATH="{dir}:$PATH"',
+  'prefs.cliUnsupported': 'O comando de terminal não está disponível nesta plataforma.',
   'prefs.spotify': 'Spotify',
   'prefs.spotifyDesc': 'Configure o aplicativo do Spotify usado no widget Now Playing.',
   'prefs.discordPresence': 'Rich Presence do Discord',
@@ -1156,6 +1168,7 @@ export const ptBR: Record<MessageKey, string> = {
   'notif.responded': '{label} respondeu.',
   'notif.responseReadyInPath': 'Resposta pronta em {path}.',
   'notif.responseReady': 'Resposta pronta.',
+  'notif.cliProjectCreated': 'Projeto criado pelo terminal',
   'notif.limitResetTitle': 'Limite resetado',
   'notif.limitResetBody': '{agent} — limite {window} liberado',
 

--- a/src/lib/tauri/cli.ts
+++ b/src/lib/tauri/cli.ts
@@ -1,0 +1,67 @@
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+
+/**
+ * Abertura pelo terminal (`alethe`, `alethe .`, `alethe <path>`) e instalação
+ * do comando no PATH. Backend em `src-tauri/src/cli_launch.rs` e `cli_shim.rs`.
+ */
+
+/** Evento com o diretório pedido pelo terminal (app já aberto). */
+const OPEN_PATH_EVENT = 'alethe://open-path'
+
+export type CliShimStatus = {
+  /** `false` onde não sabemos instalar o comando. */
+  supported: boolean
+  installed: boolean
+  /** Instalado, mas apontando pro binário antigo (app movido/reinstalado). */
+  stale: boolean
+  path: string | null
+  binDir: string | null
+  /** O diretório do shim está no PATH — quando `false`, a UI mostra como somar. */
+  onPath: boolean
+}
+
+/** O Rust serializa em snake_case; normalizamos na fronteira do IPC. */
+type RawCliShimStatus = {
+  supported: boolean
+  installed: boolean
+  stale: boolean
+  path: string | null
+  bin_dir: string | null
+  on_path: boolean
+}
+
+function toCliShimStatus(raw: RawCliShimStatus): CliShimStatus {
+  return {
+    supported: raw.supported,
+    installed: raw.installed,
+    stale: raw.stale,
+    path: raw.path,
+    binDir: raw.bin_dir,
+    onPath: raw.on_path,
+  }
+}
+
+/**
+ * Diretório pedido no cold start (`alethe <path>` com o app fechado). Consome
+ * uma única vez no backend — chamadas seguintes devolvem `null`.
+ */
+export async function cliTakePendingOpen(): Promise<string | null> {
+  return invoke<string | null>('cli_take_pending_open')
+}
+
+export async function cliShimStatus(): Promise<CliShimStatus> {
+  return toCliShimStatus(await invoke<RawCliShimStatus>('cli_shim_status'))
+}
+
+export async function cliShimInstall(): Promise<CliShimStatus> {
+  return toCliShimStatus(await invoke<RawCliShimStatus>('cli_shim_install'))
+}
+
+export async function cliShimUninstall(): Promise<CliShimStatus> {
+  return toCliShimStatus(await invoke<RawCliShimStatus>('cli_shim_uninstall'))
+}
+
+export function listenCliOpenPath(handler: (path: string) => void): Promise<UnlistenFn> {
+  return listen<string>(OPEN_PATH_EVENT, (event) => handler(event.payload))
+}

--- a/src/lib/tauri/index.ts
+++ b/src/lib/tauri/index.ts
@@ -3,6 +3,7 @@
 // importando de `.../lib/tauri` sem mudança — este barrel resolve tudo.
 
 export * from './agents'
+export * from './cli'
 export * from './filesystem'
 export * from './git'
 export * from './graphify'


### PR DESCRIPTION
## What changed

Adiciona o comando `alethe` pra abrir uma pasta como projeto direto do terminal — `alethe`, `alethe .` ou `alethe ~/algum/projeto`. Se a pasta já for um projeto, ele é trazido pro workspace em vez de duplicado; se não for, o projeto é criado com um terminal já apontando pra ela. Com o app aberto, a janela existente é focada em vez de subir uma segunda instância.

O plugin `tauri-plugin-single-instance` já estava registrado, mas o callback descartava `_argv`/`_cwd` (`lib.rs:135`) — é exatamente por ali que a entrega do diretório passa agora.

Closes #21

### Como funciona

| Situação | Caminho |
|---|---|
| App fechado | `argv` é resolvido no `setup` e guardado em `PendingOpen`; o frontend consome uma vez no boot (a webview ainda não existe no `setup`) |
| App aberto | O callback do single-instance resolve o `argv`/`cwd` da segunda instância (que morre em seguida) e emite `alethe://open-path` pra janela viva |

O binário **só** abre projeto quando recebe caminho explícito. Abrir pelo ícone não passa caminho nenhum, e cair no `cwd` nesse caso criaria projeto de `/` ou `C:\Windows\system32`. Quem transforma o `alethe` sem argumento em `--open-path $PWD` é o shim.

### Instalação do comando

Em **Configurações ▸ Integrações ▸ Comando de terminal** (ação explícita do usuário, como o "Install 'code' command in PATH" do VS Code):

| Plataforma | Caminho | PATH |
|---|---|---|
| macOS / Linux | `~/.local/bin/alethe` | já é convenção; a tela avisa se não estiver |
| Windows | `%LOCALAPPDATA%\Alethe\bin\alethe.cmd` | registrado em `HKCU\Environment` |

Em Unix não mexo em `.zshrc`/`.bashrc` nem peço sudo pra escrever em `/usr/local/bin` — instalar é ação explícita, mas nem por isso deve editar o rc do usuário. A tela também detecta shim apontando pra uma cópia antiga do app (depois de mover/reinstalar) e oferece reinstalar.

### Dois detalhes que valem o olhar na review

- **PATH do registro no Windows:** o valor é reescrito preservando o `RegType` original. Se o PATH do usuário é `REG_EXPAND_SZ` (comum, com entradas tipo `%USERPROFILE%\bin`) e a gente devolvesse `REG_SZ`, toda variável pararia de expandir — PATH quebrado pro usuário inteiro.
- **Comparação de pasta:** usa o `sameCwd` que já existe, que só normaliza caixa/separador quando o caminho é claramente do Windows. Sem isso, cada `alethe .` no Windows criaria um projeto novo pra mesma pasta.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor / chore

## Screenshots

**Configurações ▸ Integrações ▸ Comando de terminal** — comando ainda não instalado:

<img src="https://raw.githubusercontent.com/eudehh/alethe-agents/pr-assets-cli/shots/cli-command-en-dark.png" width="820">

Instalado, com aviso de diretório fora do PATH:

<img src="https://raw.githubusercontent.com/eudehh/alethe-agents/pr-assets-cli/shots/cli-command-en-dark-notonpath.png" width="820">

Tema claro (tudo via token de `theme.css`, sem cor hardcoded):

<img src="https://raw.githubusercontent.com/eudehh/alethe-agents/pr-assets-cli/shots/cli-command-en-light.png" width="820">

## Tested on

- [ ] Windows
- [x] macOS
- [ ] Linux

Testado no macOS. O caminho do Windows (registro + `.cmd`) não foi executado numa máquina Windows — foi compilado contra o target `x86_64-pc-windows-msvc` e revisado, mas agradeço se alguém puder rodar de fato. Linux não testado.

## Checklist

- [x] `npm run build` passes (typecheck + build)
- [x] `npm test` passes
- [x] `npm run format` was run
- [x] User-facing strings go through `t()` and exist in both `en.ts` and `pt-BR.ts`
- [x] Colors/spacing use tokens from `styles/theme.css` — no hardcoded values
- [x] `docs/CHANGELOG.md` updated under `[Não lançado]`

### Testes

25 testes novos, todos rodando no CI:

- **Rust (17)** — resolução de `argv` (flag, `--open-path=`, posicional, `-psn_0_1234` do macOS, sem argumento, `.`, relativo, arquivo → pasta que o contém, caminho inexistente), prefixo verbatim do Windows (`\\?\C:\…` e `\\?\UNC\…`), geração do shim (marcador do binário, detecção de shim obsoleto, escape de aspa simples) e `sh -n` sobre o script gerado — shim é código gerado, um erro de sintaxe só apareceria pro usuário na hora de rodar `alethe`.
- **vitest (8)** — decisão abrir-existente vs. criar, incluindo o match case-insensitive só no Windows e o case-sensitive no POSIX.

`npm run format` foi rodado só nos arquivos deste PR: o repo tem 12 arquivos que já falham `format:check` no `main`, e reformatá-los aqui viraria ruído de review.
