### PR TITLE
Use status tokens for UserProfile danger styles

### DIFF
--- a/src/components/UserProfile/UserProfile.module.css
+++ b/src/components/UserProfile/UserProfile.module.css
@@ -158,8 +158,8 @@
 }
 
 .dangerItem {
-  color: #ef4444;
+  color: var(--status-offline);
 }
 .dangerItem:hover {
-  background: rgba(239, 68, 68, 0.12);
+  background: var(--status-offline-soft);
 }


### PR DESCRIPTION
## What changed

Replaced hardcoded offline status colors in `UserProfile.module.css` with the corresponding theme tokens:
- `var(--status-offline)`
- `var(--status-offline-soft)`

This allows the danger item to follow the active theme instead of always using the dark theme's colors.

Closes #89

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor / chore

## Screenshots

Unable to provide screenshots because the local Tauri application could not be launched. `npm run app` was blocked by a Windows Application Control policy (`os error 4551`).

## Tested on

- [ ] Windows
- [ ] macOS
- [ ] Linux

## Checklist

- [ ] `npm run build` passes (blocked by Windows Application Control policy)
- [ ] `npm test` passes
- [ ] `npm run format` was run
- [ ] User-facing strings go through `t()` and exist in both `en.ts` and `pt-BR.ts`
- [x] Colors/spacing use tokens from `styles/theme.css` — no hardcoded values
- [ ] `docs/CHANGELOG.md` updated under `[Não lançado]` (features only)