### PR TITLE
fix: use theme tokens for danger button colors

### DIFF
--- a/src/components/modals/controls.module.css
+++ b/src/components/modals/controls.module.css
@@ -94,13 +94,13 @@ select.input {
 }
 
 .btnDanger {
-  background: #dc2626;
-  border-color: #dc2626;
-  color: #fff;
+  background: var(--status-offline);
+  border-color: var(--status-offline);
+  color: var(--accent-on);
 }
 .btnDanger:hover:not(:disabled) {
-  background: #b91c1c;
-  border-color: #b91c1c;
+  background: color-mix(in srgb, var(--status-offline) 85%, #000);
+  border-color: color-mix(in srgb, var(--status-offline) 85%, #000);
 }
 
 .pillRow {


### PR DESCRIPTION
## Summary

Replaces the hardcoded danger palette in `src/components/modals/controls.module.css` with theme tokens so the button adapts to every theme.

## Changes

- `background` and `border-color` use `var(--status-offline)`.
- Text uses `var(--accent-on)`.
- Hover darkens the theme-aware status color with `color-mix()`.

## Verification

- `npx prettier --check src/components/modals/controls.module.css` passes.
- `npm run build` passes.

Refs #31