### PR TITLE
fix: use theme tokens for memory analytics status colors

### DIFF
--- a/src/components/modals/MemoryAnalyticsModal.module.css
+++ b/src/components/modals/MemoryAnalyticsModal.module.css
@@ -47,11 +47,11 @@
 }
 
 .hot {
-  color: #ef4444 !important;
+  color: var(--status-offline);
 }
 
 .cool {
-  color: #22c55e !important;
+  color: var(--status-working);
 }
 
 .panel {


### PR DESCRIPTION
## Summary

Replaces the hardcoded status palette in `MemoryAnalyticsModal.module.css` with theme tokens.

## Changes

- `.hot` uses `var(--status-offline)`.
- `.cool` uses `var(--status-working)`.
- Drops `!important` because the scoped class selectors no longer need it.

## Verification

- `npx prettier --check src/components/modals/MemoryAnalyticsModal.module.css` passes.
- `npm run build` passes.

Refs #31