### PR TITLE
fix(theme): use defined status tokens instead of undefined ones

### DIFF
--- a/src/components/ProjectSidebar/GitControl.module.css
+++ b/src/components/ProjectSidebar/GitControl.module.css
@@ -358,7 +358,7 @@
   padding: 24px 16px;
 }
 .clean svg {
-  color: var(--status-success);
+  color: var(--status-working);
 }
 .clean strong,
 .message strong {

--- a/src/components/modals/ClaudeHistoryModal.module.css
+++ b/src/components/modals/ClaudeHistoryModal.module.css
@@ -104,7 +104,7 @@
 }
 .actionBtn:hover {
   background: var(--accent);
-  color: var(--fg-on-accent, #fff);
+  color: var(--accent-on);
   border-color: var(--accent);
 }
 .actionBtn:disabled {

--- a/src/components/modals/ProfilesModal.module.css
+++ b/src/components/modals/ProfilesModal.module.css
@@ -174,19 +174,19 @@
   line-height: 1.4;
 }
 .feedbackError {
-  color: var(--status-error, #f87171);
-  background: color-mix(in srgb, var(--status-error, #f87171) 12%, transparent);
+  color: var(--status-offline);
+  background: color-mix(in srgb, var(--status-offline) 12%, transparent);
 }
 .feedbackNotice {
-  color: var(--status-success, #4ade80);
-  background: color-mix(in srgb, var(--status-success, #4ade80) 12%, transparent);
+  color: var(--status-working);
+  background: color-mix(in srgb, var(--status-working) 12%, transparent);
 }
 .deletePanel {
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 14px;
-  border-color: color-mix(in srgb, var(--status-error, #f87171) 50%, var(--border));
+  border-color: color-mix(in srgb, var(--status-offline) 50%, var(--border));
 }
 .deleteHeader {
   display: flex;
@@ -194,7 +194,7 @@
   gap: 12px;
 }
 .deleteHeader h3 {
-  color: var(--status-error, #f87171);
+  color: var(--status-offline);
 }
 .closeDelete {
   display: grid;


### PR DESCRIPTION
Three theme tokens were read by CSS Modules but never defined in `src/styles/theme.css`. Because `var(--token, fallback)` falls back silently, those rules rendered the same hardcoded color in all ten themes instead of following the active theme. This swaps them for the tokens that already carry the same meaning and drops the hardcoded fallbacks.

Closes #30

## Token mapping

| Undefined token | Replaced with | Meaning |
|---|---|---|
| `--status-error` | `--status-offline` | error / offline |
| `--status-success` | `--status-working` | success / working |
| `--fg-on-accent` | `--accent-on` | text on an accent background |

All three replacements are defined for every theme in `theme.css`.

## Files

- `src/components/modals/ProfilesModal.module.css` — 6 lines (`.feedbackError`, `.feedbackNotice`, `.deletePanel`, `.deleteHeader h3`)
- `src/components/modals/ClaudeHistoryModal.module.css` — 1 line (`.actionBtn:hover`)
- `src/components/ProjectSidebar/GitControl.module.css` — 1 line (`.clean svg`) — **see note below**

## One extra occurrence, outside the issue list

The issue lists two files, but `GitControl.module.css:361` also reads `--status-success`, and there it has **no fallback at all**:

```css
.clean svg {
  color: var(--status-success);
}
```

An undefined custom property with no fallback makes the declaration invalid at computed-value time, so the "working tree is clean" icon inherits `--fg-muted` from `.clean` and is never green — in any theme. Since it is the same undefined token named in the issue title, I included the one-line fix so no reference to `--status-success` is left behind. Happy to drop it from this PR if you would rather keep the change strictly to the two files you listed.

## Verification

- No reference to `--status-error`, `--status-success` or `--fg-on-accent` remains anywhere in the repo.
- Every replacement token (`--status-offline`, `--status-working`, `--accent-on`) is defined in all theme blocks in `theme.css`.
- CSS-only change: no JavaScript, no markup, no i18n keys, no changelog entry (bug fix).

**Tested on:** Windows 11. Not run on macOS or Linux — the change is a pure CSS custom-property swap with no platform-specific behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
