### PR TITLE
fix: use theme token for agent picker waiting colors

### DIFF
--- a/src/components/modals/agentPicker.module.css
+++ b/src/components/modals/agentPicker.module.css
@@ -79,13 +79,13 @@
 }
 
 .bolt {
-  color: #fbbf24;
-  fill: #fbbf24;
+  color: var(--status-waiting);
+  fill: var(--status-waiting);
 }
 
 .boltActive {
   background: rgba(251, 191, 36, 0.18);
-  color: #fbbf24;
+  color: var(--status-waiting);
   outline: 1px solid rgba(251, 191, 36, 0.5);
 }
 .boltActive:hover {


### PR DESCRIPTION
## Summary

Replaces the hardcoded waiting-status color in `agentPicker.module.css` with `var(--status-waiting)`.

## Changes

- `.bolt` color and fill use `var(--status-waiting)`.
- `.boltActive` color uses `var(--status-waiting)`.

## Verification

- `npx prettier --check src/components/modals/agentPicker.module.css` passes.
- `npm run build` passes.

Refs #31