### PR TITLE
fix: use theme background for link viewer

### DIFF
--- a/src/components/LinkViewerOverlay/LinkViewerOverlay.module.css
+++ b/src/components/LinkViewerOverlay/LinkViewerOverlay.module.css
@@ -69,7 +69,7 @@
 .body {
   flex: 1;
   min-height: 0;
-  background: #fff;
+  background: var(--bg);
 }
 
 .frame {


### PR DESCRIPTION
## Summary

Replaces the hardcoded `#fff` body background in `LinkViewerOverlay.module.css` with `var(--bg)`.

## Verification

- `npx prettier --check src/components/LinkViewerOverlay/LinkViewerOverlay.module.css` passes.
- `npm run build` passes.

Refs #31