### PR TITLE
fix: use accent-on token in HomeView project badges

### DIFF
--- a/src/components/HomeView/HomeView.module.css
+++ b/src/components/HomeView/HomeView.module.css
@@ -644,7 +644,7 @@
   place-items: center;
   font-size: 15px;
   font-weight: 600;
-  color: #fff;
+  color: var(--accent-on);
   background: var(--accent);
 }
 
@@ -872,7 +872,7 @@
   place-items: center;
   font-size: 15px;
   font-weight: 600;
-  color: #fff;
+  color: var(--accent-on);
   background: var(--accent);
 }
 


### PR DESCRIPTION
## Summary

Replaces the two hardcoded `#fff` badge text colors in `HomeView.module.css` with `var(--accent-on)`.

## Verification

- `npx prettier --check src/components/HomeView/HomeView.module.css` passes.
- `npm run build` passes.

Refs #31