### PR TITLE
fix(i18n): translate sidebar search label

### DIFF
--- a/src/components/ProjectSidebar/index.tsx
+++ b/src/components/ProjectSidebar/index.tsx
@@ -418,10 +418,10 @@ export function ProjectSidebar() {
           type="button"
           className={styles.quickNavItem}
           onClick={() => openModal('findJump')}
-          title="Search"
+          title={t('ui.sidebar.search')}
         >
           <Search size={15} className={styles.quickNavIcon} />
-          <span>Search</span>
+          <span>{t('ui.sidebar.search')}</span>
         </button>
       </div>
 

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -925,6 +925,7 @@ export const en = {
   'ui.sidebar.home': 'Home',
   'ui.sidebar.homeTitle': 'Home ({shortcut})',
   'ui.sidebar.projects': 'Projects',
+  'ui.sidebar.search': 'Search',
   'ui.sidebar.explorer': 'Explorer',
   'ui.sidebar.navigation': 'Sidebar navigation',
   'ui.sidebar.archiveGroup': 'Archive group',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -933,6 +933,7 @@ export const ptBR: Record<MessageKey, string> = {
   'ui.sidebar.home': 'Início',
   'ui.sidebar.homeTitle': 'Início ({shortcut})',
   'ui.sidebar.projects': 'Projetos',
+  'ui.sidebar.search': 'Buscar',
   'ui.sidebar.explorer': 'Explorer',
   'ui.sidebar.navigation': 'Navegacao da barra lateral',
   'ui.sidebar.archiveGroup': 'Arquivar grupo',


### PR DESCRIPTION
Closes #48 (ProjectSidebar/index.tsx)

## Summary

Converts the hardcoded Search label in the project sidebar quick navigation to `t(ui.sidebar.search)` and adds the key to both message files.

## Verification

- `npx tsc --noEmit` passes.
- ESLint passes on the changed component (only the pre-existing import-sort warning remains).
- `git diff --check` passes.

Signed off with DCO.