### PR TITLE
fix(i18n): translate native terminal settings

### DIFF
--- a/src/components/modals/preferences/TerminalPage.tsx
+++ b/src/components/modals/preferences/TerminalPage.tsx
@@ -285,8 +285,8 @@ export function TerminalPage({ enabledCount }: { enabledCount: number }) {
       {isMacOS() ? (
         <SettingsSection
           id="native-terminal-macos"
-          title="Terminal nativo (Ghostty)"
-          description="Use the embedded Ghostty engine (GPU rendering) instead of the internal terminal. Experimental. Reopen terminals after changing this."
+          title={t('prefs.nativeTerminalMacos')}
+          description={t('prefs.nativeTerminalMacosDesc')}
         >
           <label
             style={{
@@ -305,7 +305,7 @@ export function TerminalPage({ enabledCount }: { enabledCount: number }) {
               checked={preferences.nativeTerminalMacos ?? false}
               onChange={(e) => setPreferences({ nativeTerminalMacos: e.target.checked })}
             />
-            <span style={{ flex: 1, fontSize: 13 }}>Habilitar terminal nativo (macOS)</span>
+            <span style={{ flex: 1, fontSize: 13 }}>{t('prefs.nativeTerminalMacosEnable')}</span>
           </label>
         </SettingsSection>
       ) : null}

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -322,6 +322,10 @@ export const en = {
   'dictation.unsupported': 'Voice input is not available in this build.',
   'prefs.terminalTheme': 'Terminal theme',
   'prefs.terminalThemeDesc': 'Follow the interface theme or choose a dedicated terminal palette.',
+  'prefs.nativeTerminalMacos': 'Native terminal (Ghostty)',
+  'prefs.nativeTerminalMacosDesc':
+    'Use the embedded Ghostty engine (GPU rendering) instead of the internal terminal. Experimental. Reopen terminals after changing this.',
+  'prefs.nativeTerminalMacosEnable': 'Enable native terminal (macOS)',
   'prefs.resourcePolicy': 'Memory protection',
   'prefs.resourcePolicyDesc':
     'Set a total app budget and park hidden idle runtimes before Windows runs out of memory.',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -322,6 +322,10 @@ export const ptBR: Record<MessageKey, string> = {
   'prefs.terminalTheme': 'Tema do terminal',
   'prefs.terminalThemeDesc':
     'Use o tema da interface ou escolha uma paleta exclusiva para terminais.',
+  'prefs.nativeTerminalMacos': 'Terminal nativo (Ghostty)',
+  'prefs.nativeTerminalMacosDesc':
+    'Use o mecanismo Ghostty integrado (renderização por GPU) em vez do terminal interno. Experimental. Reabra os terminais após alterar esta opção.',
+  'prefs.nativeTerminalMacosEnable': 'Habilitar terminal nativo (macOS)',
   'prefs.resourcePolicy': 'Proteção de memória',
   'prefs.resourcePolicyDesc':
     'Define um orçamento total do app e estaciona runtimes ocultos e ociosos antes de o Windows ficar sem memória.',


### PR DESCRIPTION
Closes #48 (`TerminalPage.tsx`)

## Summary

Replaces the hardcoded native terminal title with an i18n key and translates the two additional user-facing strings found in the same macOS settings section: its description and checkbox label. Adds matching English and Brazilian Portuguese messages so the whole section follows the selected language.

## Verification

- `npm run build` passes.
- `npm test` passes (13 files, 74 tests).
- `npm run lint` completes with no errors; existing repository warnings remain.
- `git diff --check` passes.
- Tested on Fedora Linux; the macOS-only screen was not visually tested.