### PR TITLE
docs: fix typo 'runnig' -> 'running' in Linux screenshot alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
       <img src="./docs/screenshots/alethe-windows.png" alt="Alethe running on Windows" width="100%">
     </td>
     <td align="center">
-      <img src="./docs/screenshots/alethe-linux.png" alt="Alethe runnig on Linux" width="100%">
+      <img src="./docs/screenshots/alethe-linux.png" alt="Alethe running on Linux" width="100%">
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## Summary

- Small alt-text typo fix in `README.md`
- Line 60: `alt="Alethe runnig on Linux"` → `alt="Alethe running on Linux"`

## Test plan

- [x] `git diff` shows a single-line change
- [x] Rendered README preserves layout (screenshot table intact)