### PR TITLE
docs: add theme contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Roughly ordered from "you can do this today" to "talk to us first":
 3. **Validate a platform.** Alethe is Windows-first and still under-tested on Linux and macOS.
    Running it on your machine and reporting exactly what broke is genuinely useful.
 4. **Improve docs, screenshots, or setup notes.** If something confused you during setup, you're
-   the best-positioned person in the world to fix it.
+   the best-positioned person in the world to fix it. See the [theme guide](docs/THEMES.md) for adding or documenting themes.
 5. **Pick a [`help wanted`](https://github.com/Kc1t/alethe-agents/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issue.**
    Bigger, less hand-held, still well-defined.
 6. **Propose a feature.** Open an issue describing the *workflow* it would improve before writing

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,49 +1,66 @@
-### Adding a Theme to Alethe
+# Adding a Theme to Alethe
 
-Adding a custom theme is a great first contribution—it's visual, self-contained, and satisfying. However, because Alethe splits its interface layout and terminal panes, a theme actually touches **seven different files**. 
+Adding a custom theme is a great first contribution—it's visual, self-contained, and satisfying. In Alethe, a theme touches seven files/locations because the application UI and terminal palette are configured separately.
 
-If you miss a step, things fail quietly. For example, skipping the CSS tokens means your theme appears in the picker but renders with the old layout's colors. Skipping the xterm object means your application container updates but the text inside the terminal window stays exactly the same. 
+Follow these touchpoints from top to bottom when adding a theme.
 
-Follow this checklist from top to bottom to make sure your theme integrates cleanly. 
-
-### The 7 Touchpoints
+## The 7 Touchpoints
 
 ### 1. Register the Theme ID
 
-Add your theme's unique identifier string to the central type union. 
+Add your theme's unique identifier to the `Theme` union.
 
-* **File:** src/lib/types.ts
+**File:** `src/lib/types.ts`
 
-typescript
+For example, the existing `nord` theme is registered like this:
 
-// Look near line 61 and append your string key:
-export type Theme = 'dark' | 'light' | 'nord' | 'your-theme-id';
+```typescript
+export type Theme =
+  | 'dark'
+  | 'light'
+  | 'dracula'
+  | 'nord'
+  | 'gruvbox'
+  | 'solarized'
+  | 'tokyo-night'
+  | 'vscode'
+  | 'min-dark'
+  | 'min-light'
+  | 'dark-lemon'
+  | 'orca'
+```
 
-Use code with caution.
+Add your new theme ID to this union.
 
 ### 2. Configure the Swatch Preview
 
-Add an entry to the THEME_OPTIONS array. This controls the 3-color circular badge displayed inside the settings dropdown container. 
+Add an entry to `THEME_OPTIONS`. The three colors are used for the theme swatch shown in the theme picker.
 
-* **File:** src/lib/themes.ts
+**File:** `src/lib/themes.ts`
 
-typescript
+The existing `nord` entry is:
 
-{ id: 'nord', colors: ['#2e3440', '#88c0d0', '#eceff4'] },
+```typescript
+{ id: 'nord', colors: ['#2e3440', '#88c0d0', '#a3be8c'] },
+```
 
-Use code with caution.
+The three colors represent, roughly:
 
-* **Swatch Rules:** The array format maps strictly to [Background, Accent, Foreground]. Select values that capture the primary characteristics of your palette.
+1. Background
+2. Accent
+3. Foreground
+
+Choose colors that represent the main visual characteristics of your theme.
 
 ### 3. Implement the UI Token Variables
 
-This block controls the actual CSS custom variables for the interface frame, panels, and borders. 
+Add a `[data-theme='<id>']` block containing the theme's CSS custom properties.
 
-* **File:** src/styles/theme.css
-* **Action:** Wrap your variables inside a [data-theme='<id>'] structural block using the nord setup as an accurate implementation template:
+**File:** `src/styles/theme.css`
 
-css
+The existing `nord` block is:
 
+```css
 [data-theme='nord'] {
   --bg: #2e3440;
   --bg-elevated: #3b4252;
@@ -53,88 +70,197 @@ css
   --border: #4c566a;
   --border-strong: rgba(236, 239, 244, 0.24);
   --fg: #eceff4;
-  /* ... copy other theme custom tokens here ... */
+  --fg-muted: #d8dee9;
+  --fg-faint: #aeb8c8;
+  --text-primary: #eceff4;
+  --text-secondary: #d8dee9;
+  --text-tertiary: #aeb8c8;
+  --text-quaternary: #7f8ca2;
+  --accent: #88c0d0;
+  --accent-strong: #8fbcbb;
+  --accent-on: #2e3440;
+  --accent-soft: rgba(136, 192, 208, 0.14);
+  --accent-faint: rgba(136, 192, 208, 0.14);
+  --accent-border: rgba(136, 192, 208, 0.42);
+  --accent-ring: rgba(136, 192, 208, 0.18);
+  --accent-bg-soft: rgba(136, 192, 208, 0.14);
+  --accent-border-soft: rgba(136, 192, 208, 0.36);
+  --surface-modal: #3b4252;
+  --surface-card-default: #434c5e;
+  --surface-card-default-strong: #4c566a;
+  --surface-card-selected: rgba(136, 192, 208, 0.14);
+  --border-subtle: #4c566a;
+  --border-accent: rgba(136, 192, 208, 0.42);
+  --status-working: #a3be8c;
+  --status-working-soft: rgba(163, 190, 140, 0.16);
+  --status-waiting: #ebcb8b;
+  --status-waiting-soft: rgba(235, 203, 139, 0.16);
+  --status-stopped: #aeb8c8;
+  --status-stopped-soft: rgba(174, 184, 200, 0.14);
+  --status-disabled: #4c566a;
+  --status-offline: #bf616a;
+  --status-offline-soft: rgba(191, 97, 106, 0.16);
+  --agent-shell: #a3be8c;
+  --agent-claude: #d08770;
+  --agent-codex: #88c0d0;
+  --agent-opencode: #b48ead;
+  --focus-ring: #88c0d0;
+  --shape-tabs-lane-bg: #242933;
+  --shape-tabs-lane-border: rgba(236, 239, 244, 0.08);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.42);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.54);
 }
+```
 
-Use code with caution.
+The `dark` block defines these groups of tokens:
 
-* **Note on Inheritance:** Read through the global :root block at the top of the file. If certain secondary or fallback tokens fit your design perfectly, you can safely omit them here because they inherit from :root automatically.
+- **Surfaces:** `--bg`, `--bg-elevated`, `--bg-sunken`, `--panel`, `--panel-hover`, `--border`, `--border-strong`
+- **Text:** `--fg`, `--fg-muted`, `--fg-faint`, `--text-primary`, `--text-secondary`, `--text-tertiary`, `--text-quaternary`
+- **Accent:** `--accent`, `--accent-strong`, `--accent-on`, `--accent-soft`, `--accent-faint`, `--accent-border`, `--accent-ring`, `--accent-bg-soft`, `--accent-border-soft`
+- **Cards and surfaces:** `--surface-modal`, `--surface-card-default`, `--surface-card-default-strong`, `--surface-card-selected`, `--border-subtle`, `--border-accent`
+- **Status:** `--status-working`, `--status-working-soft`, `--status-waiting`, `--status-waiting-soft`, `--status-stopped`, `--status-stopped-soft`, `--status-disabled`, `--status-offline`, `--status-offline-soft`, `--status-active`, `--status-idle`
+- **Agent colors:** `--agent-shell`, `--agent-claude`, `--agent-codex`, `--agent-opencode`, `--agent-freebuff`, `--agent-mimo`, `--agent-antigravity`, `--agent-shell-soft`, `--agent-claude-soft`, `--agent-codex-soft`, `--agent-opencode-soft`, `--agent-freebuff-soft`, `--agent-mimo-soft`, `--agent-antigravity-soft`
+- **Focus:** `--focus-ring`
+- **Tabs lane:** `--shape-tabs-lane-bg`, `--shape-tabs-lane-border`
+- **Shadows:** `--shadow-sm`, `--shadow-md`, `--shadow-lg`
+- **Shape and typography:** `--radius-sm`, `--radius-md`, `--radius-lg`, `--font-sans`, `--font-mono`
 
-### 4. English Localization
+The animation tokens (`--anim-instant`, `--anim-fast`, `--anim-normal`, `--anim-slow`, `--ease-spring`, `--ease-out-fluid`, and `--ease-in-out-fluid`) are also defined in the `:root`/`dark` block.
 
-Add the user-facing name and description string keys to the flat dictionary. 
+A theme does not have to repeat every token. The `:root` selector provides fallback values for tokens that a theme block omits, so only the values that need to change for the new theme need to be overridden. Existing themes are the best reference for which tokens are worth customizing.
 
-* **File:** src/lib/i18n/messages/en.ts
+### 4. Add English Localization
 
-typescript
+Add the user-facing name and description.
 
+**File:** `src/lib/i18n/messages/en.ts`
+
+The existing `nord` entries are:
+
+```typescript
 /* ---- theme labels ---- */
 'theme.nord.label': 'Nord',
 'theme.nord.desc': 'Cool blues and soft contrast.',
+```
 
-Use code with caution.
+Use the same key format for the new theme:
 
-### 5. Portuguese (pt-BR) Localization
+```typescript
+'theme.<id>.label': '<Theme Name>',
+'theme.<id>.desc': '<Short description>',
+```
 
-Duplicate the keys in the Portuguese file to ensure regional users don't see broken layout tags. If you do not speak Portuguese, use a machine translation tool or mirror the English label text for the maintainers to adjust later. 
+### 5. Add Portuguese (`pt-BR`) Localization
 
-* **File:** src/lib/i18n/messages/pt-BR.ts
+Add the same two keys to the Portuguese translation file.
 
-typescript
+**File:** `src/lib/i18n/messages/pt-BR.ts`
 
+The existing `nord` entries are:
+
+```typescript
 /* ---- theme labels ---- */
 'theme.nord.label': 'Nord',
 'theme.nord.desc': 'Azuis frios e contraste suave.',
+```
 
-Use code with caution.
+The keys must match the English file exactly. The Portuguese values should be translated appropriately.
 
-### 6. Map the Terminal Palette Profile
+### 6. Map the Terminal Palette
 
-Because terminal pane components rely on an isolated rendering module (xterm.js), they cannot read standard CSS variables. You must explicitly define your console variables here. 
+The terminal uses xterm.js and has its own color palette, so it must be updated separately from the application CSS.
 
-* **File:** src/components/XTermView/xtermThemes.ts
-* **Action:** Define your constant profile object at the top, then register it with a conditional handler switch inside the getXtermTheme utility function:
+**File:** `src/components/XTermView/xtermThemes.ts`
 
-typescript
+The existing `nord` palette is:
 
+```typescript
 const NORD_THEME = {
   background: '#2e3440',
   foreground: '#eceff4',
   cursor: '#eceff4',
   selectionBackground: '#4c566a',
-  // Note: Optional ANSI overrides (black, red, green, etc.) can be included here
-} as const;
+} as const
+```
 
+Then `getXtermTheme()` registers it:
+
+```typescript
 export function getXtermTheme(theme: Theme) {
-  // Add your target check branch here:
-  if (theme === 'nord') return NORD_THEME;
-  /* ... existing theme conditions ... */
-  return DARK_THEME;
+  if (theme === 'light') return LIGHT_THEME
+  if (theme === 'dracula') return DRACULA_THEME
+  if (theme === 'nord') return NORD_THEME
+  // ...
+  return DARK_THEME
 }
+```
 
-Use code with caution.
+Add the new theme's palette and a corresponding condition in `getXtermTheme()`.
 
-### 7. Link App Graphic Icon Variants
+ANSI color overrides such as `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, and their `bright*` variants are optional. Existing themes provide examples of both minimal and full terminal palettes.
 
-Add structural support properties mapping icon variations. 
+### 7. Add the Theme Icon
 
-* **Asset Location:** src/assets/theme-icons/<your-theme-id>.png
-* **File Linker:** src/lib/themeIcons.ts
-* **Asset Rules:** Save your asset strictly as a transparent .png. Ensure your dimensions mirror the existing nord.png profile constraints perfectly.
+Add the theme's PNG asset and register it in the theme icon map.
 
-### Contrast & Design Guidelines
+**Asset:** `src/assets/theme-icons/<id>.png`
 
-Developers rely on Alethe for hours at a time during intense work sessions. 
+The existing `nord.png` is a **220 × 220 PNG with RGBA transparency**. New theme icons should use the same dimensions and PNG format.
 
-* **Avoid Eye-Strain:** Refrain from incorporating highly abrasive, over-saturated neon contrast pairs.
-* **Verify Clarity:** Make sure text elements pass clear readability evaluations over their relative background panels.
+Then update:
 
-### How to Test Your Local Changes
+**File:** `src/lib/themeIcons.ts`
 
-The best way to verify your work end-to-end is to build a dummy throwaway theme file block: 
+The existing `nord` import and mapping are:
 
-1. Run npm run dev to start the local developer runtime engine.
-2. Go to **Preferences > Appearance** inside your browser view.
-3. Switch to your new theme. Check both the overall UI layout containers *and* an open terminal panel.
-4. Confirm everything transitions smoothly without color bleeding, then delete your scratch work before pushing your PR updates!
+```typescript
+import nordIcon from '../assets/theme-icons/nord.png'
+
+export const THEME_ICONS: Record<AppIconTheme, string> = {
+  dark: darkIcon,
+  light: lightIcon,
+  dracula: draculaIcon,
+  nord: nordIcon,
+  // ...
+}
+```
+
+Add the new icon import and its entry in `THEME_ICONS`.
+
+## Contrast & Design Guidelines
+
+Alethe has both dark and light themes and is intended for long development sessions. Do not ship foreground/background combinations that are difficult to read.
+
+Check the actual text, muted text, accents, borders, and terminal text against their backgrounds. Avoid highly saturated combinations where the foreground and background visually fight each other. The final theme should remain comfortable to read for extended periods.
+
+## How to Test Your Local Changes
+
+The issue can be verified by following the documentation with a temporary theme:
+
+1. Create a throwaway theme and follow all seven touchpoints above.
+2. Run `npm run dev` for frontend-only UI work.
+3. Go to **Preferences > Appearance**.
+4. Switch to the new theme.
+5. Check the theme picker and swatch.
+6. Check the application UI.
+7. Check the theme icon.
+8. Open a terminal and check its background, text, cursor, selection, and terminal colors.
+9. Switch between the new theme and another theme to make sure both UI and terminal colors update correctly.
+10. Delete the throwaway theme before committing.
+
+For work that requires the terminal/backend, use `npm run app` instead of `npm run dev`.
+
+## Final Checklist
+
+```text
+[ ] Theme ID added to src/lib/types.ts
+[ ] Theme swatch added to src/lib/themes.ts
+[ ] UI tokens added to src/styles/theme.css
+[ ] English localization added to src/lib/i18n/messages/en.ts
+[ ] Portuguese localization added to src/lib/i18n/messages/pt-BR.ts
+[ ] xterm palette added to src/components/XTermView/xtermThemes.ts
+[ ] Theme icon PNG added to src/assets/theme-icons/
+[ ] Theme icon registered in src/lib/themeIcons.ts
+[ ] Picker, UI, terminal, and icon tested locally
+```

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,0 +1,140 @@
+### Adding a Theme to Alethe
+
+Adding a custom theme is a great first contribution—it's visual, self-contained, and satisfying. However, because Alethe splits its interface layout and terminal panes, a theme actually touches **seven different files**. 
+
+If you miss a step, things fail quietly. For example, skipping the CSS tokens means your theme appears in the picker but renders with the old layout's colors. Skipping the xterm object means your application container updates but the text inside the terminal window stays exactly the same. 
+
+Follow this checklist from top to bottom to make sure your theme integrates cleanly. 
+
+### The 7 Touchpoints
+
+### 1. Register the Theme ID
+
+Add your theme's unique identifier string to the central type union. 
+
+* **File:** src/lib/types.ts
+
+typescript
+
+// Look near line 61 and append your string key:
+export type Theme = 'dark' | 'light' | 'nord' | 'your-theme-id';
+
+Use code with caution.
+
+### 2. Configure the Swatch Preview
+
+Add an entry to the THEME_OPTIONS array. This controls the 3-color circular badge displayed inside the settings dropdown container. 
+
+* **File:** src/lib/themes.ts
+
+typescript
+
+{ id: 'nord', colors: ['#2e3440', '#88c0d0', '#eceff4'] },
+
+Use code with caution.
+
+* **Swatch Rules:** The array format maps strictly to [Background, Accent, Foreground]. Select values that capture the primary characteristics of your palette.
+
+### 3. Implement the UI Token Variables
+
+This block controls the actual CSS custom variables for the interface frame, panels, and borders. 
+
+* **File:** src/styles/theme.css
+* **Action:** Wrap your variables inside a [data-theme='<id>'] structural block using the nord setup as an accurate implementation template:
+
+css
+
+[data-theme='nord'] {
+  --bg: #2e3440;
+  --bg-elevated: #3b4252;
+  --bg-sunken: #242933;
+  --panel: #434c5e;
+  --panel-hover: #4c566a;
+  --border: #4c566a;
+  --border-strong: rgba(236, 239, 244, 0.24);
+  --fg: #eceff4;
+  /* ... copy other theme custom tokens here ... */
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.54);
+}
+
+Use code with caution.
+
+* **Note on Inheritance:** Read through the global :root block at the top of the file. If certain secondary or fallback tokens fit your design perfectly, you can safely omit them here because they inherit from :root automatically.
+
+### 4. English Localization
+
+Add the user-facing name and description string keys to the flat dictionary. 
+
+* **File:** src/lib/i18n/messages/en.ts
+
+typescript
+
+/* ---- theme labels ---- */
+'theme.nord.label': 'Nord',
+'theme.nord.desc': 'Cool blues and soft contrast.',
+
+Use code with caution.
+
+### 5. Portuguese (pt-BR) Localization
+
+Duplicate the keys in the Portuguese file to ensure regional users don't see broken layout tags. If you do not speak Portuguese, use a machine translation tool or mirror the English label text for the maintainers to adjust later. 
+
+* **File:** src/lib/i18n/messages/pt-BR.ts
+
+typescript
+
+/* ---- theme labels ---- */
+'theme.nord.label': 'Nord',
+'theme.nord.desc': 'Azuis frios e contraste suave.',
+
+Use code with caution.
+
+### 6. Map the Terminal Palette Profile
+
+Because terminal pane components rely on an isolated rendering module (xterm.js), they cannot read standard CSS variables. You must explicitly define your console variables here. 
+
+* **File:** src/components/XTermView/xtermThemes.ts
+* **Action:** Define your constant profile object at the top, then register it with a conditional handler switch inside the getXtermTheme utility function:
+
+typescript
+
+const NORD_THEME = {
+  background: '#2e3440',
+  foreground: '#eceff4',
+  cursor: '#eceff4',
+  selectionBackground: '#4c566a',
+  // Note: Optional ANSI overrides (black, red, green, etc.) can be included here
+} as const;
+
+export function getXtermTheme(theme: Theme) {
+  // Add your target check branch here:
+  if (theme === 'nord') return NORD_THEME;
+  /* ... existing theme conditions ... */
+  return DARK_THEME;
+}
+
+Use code with caution.
+
+### 7. Link App Graphic Icon Variants
+
+Add structural support properties mapping icon variations. 
+
+* **Asset Location:** src/assets/theme-icons/<your-theme-id>.png
+* **File Linker:** src/lib/themeIcons.ts
+* **Asset Rules:** Save your asset strictly as a transparent .png. Ensure your dimensions mirror the existing nord.png profile constraints perfectly.
+
+### Contrast & Design Guidelines
+
+Developers rely on Alethe for hours at a time during intense work sessions. 
+
+* **Avoid Eye-Strain:** Refrain from incorporating highly abrasive, over-saturated neon contrast pairs.
+* **Verify Clarity:** Make sure text elements pass clear readability evaluations over their relative background panels.
+
+### How to Test Your Local Changes
+
+The best way to verify your work end-to-end is to build a dummy throwaway theme file block: 
+
+1. Run npm run dev to start the local developer runtime engine.
+2. Go to **Preferences > Appearance** inside your browser view.
+3. Switch to your new theme. Check both the overall UI layout containers *and* an open terminal panel.
+4. Confirm everything transitions smoothly without color bleeding, then delete your scratch work before pushing your PR updates!


### PR DESCRIPTION
## What changed

Closes #41

- Added `docs/THEMES.md` documenting the seven theme integration touchpoints.
- Documented theme CSS tokens, swatch colors, localization, xterm palette, icon assets, contrast, and testing.
- Linked the theme guide from `CONTRIBUTING.md`.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor / chore

## Screenshots

Not applicable — documentation-only change.

## Tested on

- [ ] Windows
- [ ] macOS
- [ ] Linux

Documentation-only change; no platform-specific application behavior was modified.

## Checklist

- [ ] `npm run build` passes (typecheck + build)
- [ ] `npm test` passes
- [ ] `npm run format` was run
- [ ] User-facing strings go through `t()` and exist in both `en.ts` and `pt-BR.ts`
- [ ] Colors/spacing use tokens from `styles/theme.css` — no hardcoded values
- [ ] `docs/CHANGELOG.md` updated under `[Não lançado]` (features only)