### PR TITLE
fix: give light terminal themes a WCAG-AA palette and contrast floor (#97)

### DIFF
--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -198,7 +198,9 @@ export function getXtermTheme(theme: Theme) {
 
 Add the new theme's palette and a corresponding condition in `getXtermTheme()`.
 
-ANSI color overrides such as `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, and their `bright*` variants are optional. Existing themes provide examples of both minimal and full terminal palettes.
+ANSI color overrides such as `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, and their `bright*` variants are optional **on a dark background**. On a light background they are **mandatory**: xterm.js falls back to the dark-oriented Tango palette for any slot a light theme omits, and 8 of the 16 Tango slots fail WCAG AA (4.5:1) against a near-white background (see issue #97). Every slot a light theme ships must hold at least **4.5:1** against its own `background`.
+
+The one sanctioned exception is `white` / `brightWhite` on a light background: they double as painted backgrounds (`\x1b[47m`, `\x1b[107m` — used by `less` status bars), so they stay light and the render-time `minimumContrastRatio` floor (4.5, enabled for light themes only) darkens them when they are used as text. `docs/THEMES.md` documents both rules so the next light theme does not repeat this class of bug.
 
 ### 7. Add the Theme Icon
 
@@ -227,6 +229,8 @@ export const THEME_ICONS: Record<AppIconTheme, string> = {
 ```
 
 Add the new icon import and its entry in `THEME_ICONS`.
+
+Light themes must also keep the terminal's `minimumContrastRatio` floor: `getMinimumContrastRatio()` in `src/components/XTermView/xtermThemes.ts` returns `4.5` for light-background themes and is wired into the xterm `Terminal` options in `useXtermSession.ts` and the theme-change effect in `index.tsx`. A 16-slot palette cannot cover the 256-color / truecolor output agents emit directly; only the render-time floor can. Dark themes stay byte-identical — the floor applies to light-background themes only.
 
 ## Contrast & Design Guidelines
 

--- a/src/components/XTermView/index.tsx
+++ b/src/components/XTermView/index.tsx
@@ -31,7 +31,7 @@ import { useUiStore } from '../../stores/uiStore'
 import { type DetectedTerminalLink } from './terminalLinks'
 import { applyPromptHistoryInput, loadPromptHistory, PROMPT_HISTORY_KEY } from './terminalWrite'
 import { useXtermSession } from './useXtermSession'
-import { getXtermTheme, type LinkActionState } from './xtermThemes'
+import { getMinimumContrastRatio, getXtermTheme, type LinkActionState } from './xtermThemes'
 import styles from './XTermView.module.css'
 
 export type XTermViewProps = {
@@ -343,6 +343,9 @@ export function XTermView({
     const terminal = terminalRef.current
     if (!terminal) return
     terminal.options.theme = getXtermTheme(terminalTheme)
+    // 1 is xterm's default, so switching to a dark theme leaves rendering
+    // unchanged while light themes get the WCAG-AA floor (#97).
+    terminal.options.minimumContrastRatio = getMinimumContrastRatio(terminalTheme) ?? 1
   }, [terminalTheme])
 
   const configurePath = useCallback(

--- a/src/components/XTermView/useXtermSession.ts
+++ b/src/components/XTermView/useXtermSession.ts
@@ -80,7 +80,7 @@ import {
   makeXtermLink,
 } from './terminalLinks'
 import { TERMINAL_WRITE_FRAME_BUDGET, writePtyChunked, writePtyWithTimeout } from './terminalWrite'
-import { getXtermTheme, type LinkActionState } from './xtermThemes'
+import { getMinimumContrastRatio, getXtermTheme, type LinkActionState } from './xtermThemes'
 
 // Early exits trigger a single fresh-session retry.
 const EARLY_EXIT_MS = 4000
@@ -252,6 +252,9 @@ export function useXtermSession(params: {
       fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
       fontSize: 14,
       theme: getXtermTheme(terminalTheme),
+      // WCAG-AA render-time floor on light themes only; undefined keeps
+      // xterm's default (1) for dark themes (#97).
+      minimumContrastRatio: getMinimumContrastRatio(terminalTheme),
     })
     const fitAddon = new FitAddon()
     const searchAddon = new SearchAddon()
@@ -870,9 +873,7 @@ export function useXtermSession(params: {
         }
 
         const savedSession =
-          command && RESUMABLE_AGENTS.includes(command)
-            ? peekSession(sessionPersistenceKey)
-            : null
+          command && RESUMABLE_AGENTS.includes(command) ? peekSession(sessionPersistenceKey) : null
         const savedConversationId = savedConversationIdFor(savedSession, command, cwd)
         let resumeId = sessionId ?? savedConversationId
         // Fallback: se a tentativa anterior morreu no nascimento usando resume,
@@ -1411,7 +1412,8 @@ export function useXtermSession(params: {
           )
         }
         if (cancelled || !isPanelVisible || wasVisible) return
-        if (lastIoWhenHiddenRef.current !== null && ioAtNow() === lastIoWhenHiddenRef.current) return
+        if (lastIoWhenHiddenRef.current !== null && ioAtNow() === lastIoWhenHiddenRef.current)
+          return
         resyncTimer = window.setTimeout(() => {
           if (!cancelled) void resyncTerminalRef.current?.()
         }, PANEL_RESYNC_DEBOUNCE_MS)

--- a/src/components/XTermView/xtermThemes.test.ts
+++ b/src/components/XTermView/xtermThemes.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMinimumContrastRatio, getXtermTheme, isLightTerminalTheme } from './xtermThemes'
+
+/** sRGB channel (0..255) → linear light. */
+function linear(channel: number): number {
+  const c = channel / 255
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+function luminance(hex: string): number {
+  const h = hex.replace('#', '')
+  const r = parseInt(h.slice(0, 2), 16)
+  const g = parseInt(h.slice(2, 4), 16)
+  const b = parseInt(h.slice(4, 6), 16)
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
+}
+
+/** WCAG 2.1 contrast ratio between two colors, 1..21. */
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+// The white/brightWhite slots are intentionally light so `\x1b[47m` /
+// `\x1b[107m` painted backgrounds still read as backgrounds; the 4.5 render
+// floor handles their text role. Every other slot must pass AA directly.
+const ANSI_SLOTS = [
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+] as const
+const BACKGROUND_ROLE_SLOTS = ['white', 'brightWhite'] as const
+
+describe('light terminal palettes', () => {
+  it('every non-background ANSI slot meets WCAG AA (>= 4.5:1) on light', () => {
+    const theme = getXtermTheme('light')
+    for (const slot of ANSI_SLOTS) {
+      expect(
+        contrast(theme[slot], theme.background),
+        `${slot} (${theme[slot]})`,
+      ).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('every non-background ANSI slot meets WCAG AA (>= 4.5:1) on min-light', () => {
+    const theme = getXtermTheme('min-light')
+    for (const slot of ANSI_SLOTS) {
+      expect(
+        contrast(theme[slot], theme.background),
+        `${slot} (${theme[slot]})`,
+      ).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('keeps white/brightWhite light so they still work as painted backgrounds', () => {
+    // They cannot be dark (as foreground) and light (as `\x1b[47m` background)
+    // at once; the render-time floor covers their text role. Assert they stay
+    // close to the background rather than flipping to near-black.
+    for (const themeName of ['light', 'min-light'] as const) {
+      const theme = getXtermTheme(themeName)
+      for (const slot of BACKGROUND_ROLE_SLOTS) {
+        expect(luminance(theme[slot]), `${themeName}.${slot}`).toBeGreaterThan(0.6)
+      }
+    }
+  })
+
+  it('dark themes that omit ANSI slots keep the minimal four-key shape', () => {
+    for (const themeName of ['dark', 'nord', 'gruvbox', 'solarized', 'tokyo-night'] as const) {
+      const theme = getXtermTheme(themeName)
+      expect(Object.keys(theme).sort(), themeName).toEqual([
+        'background',
+        'cursor',
+        'foreground',
+        'selectionBackground',
+      ])
+    }
+  })
+
+  it('dark themes that ship palettes are left byte-for-byte untouched', () => {
+    // The light-theme fix must not silently alter deliberate dark choices
+    // (e.g. Dracula's brightBlack at 2.6:1). Pin the exact slot values.
+    const originals = {
+      dracula: { brightBlack: '#6272a4', yellow: '#f1fa8c' },
+      vscode: { black: '#000000', brightWhite: '#e5e5e5' },
+      'min-dark': { brightWhite: '#fafafa', yellow: '#ff9800' },
+      'dark-lemon': { brightWhite: '#ffffff', brightBlack: '#5a5a5a' },
+      ember: { brightWhite: '#ffffff', green: '#8fbf7f' },
+    } as const
+    for (const [themeName, pinned] of Object.entries(originals)) {
+      const theme = getXtermTheme(themeName as keyof typeof originals)
+      for (const [slot, hex] of Object.entries(pinned)) {
+        expect(theme[slot as keyof typeof theme], `${themeName}.${slot}`).toBe(hex)
+      }
+    }
+  })
+})
+
+describe('isLightTerminalTheme / getMinimumContrastRatio', () => {
+  it('applies the 4.5 floor only to the two light themes', () => {
+    expect(isLightTerminalTheme('light')).toBe(true)
+    expect(isLightTerminalTheme('min-light')).toBe(true)
+    expect(getMinimumContrastRatio('light')).toBe(4.5)
+    expect(getMinimumContrastRatio('min-light')).toBe(4.5)
+  })
+
+  it('leaves dark themes at xterm\u2019s default (undefined)', () => {
+    for (const themeName of [
+      'dark',
+      'dracula',
+      'nord',
+      'gruvbox',
+      'solarized',
+      'tokyo-night',
+      'vscode',
+      'min-dark',
+      'dark-lemon',
+      'ember',
+    ] as const) {
+      expect(isLightTerminalTheme(themeName), themeName).toBe(false)
+      expect(getMinimumContrastRatio(themeName), themeName).toBeUndefined()
+    }
+  })
+})

--- a/src/components/XTermView/xtermThemes.ts
+++ b/src/components/XTermView/xtermThemes.ts
@@ -1,7 +1,6 @@
 import type { Theme } from '../../lib/types'
 import type { FileLinkKind } from './terminalLinks'
 
-                                                                    
 export type LinkActionState = {
   text: string
   target: string
@@ -17,11 +16,37 @@ const DARK_THEME = {
   cursor: '#f3f4f6',
   selectionBackground: '#3b82f666',
 } as const
+// A light background inverts the usual rules: xterm.js falls back to the
+// dark-oriented Tango palette for any slot we omit, which fails WCAG AA on
+// #fafafa. Every slot below therefore ships an explicit color that keeps
+// >= 4.5:1 against the background (#97).
+//
+// The one deliberate exception is white/brightWhite: they serve a dual role
+// as both foreground text and painted background (\x1b[47m / \x1b[107m, used
+// by `less` status bars). Keeping them light lets a painted background still
+// read as a background; the `minimumContrastRatio` floor (4.5, enabled only
+// for light themes) darkens them at render time when they are used as text.
 const LIGHT_THEME = {
   background: '#fafafa',
   foreground: '#18181b',
   cursor: '#18181b',
   selectionBackground: '#3b82f655',
+  black: '#27272a',
+  red: '#b91c1c',
+  green: '#15803d',
+  yellow: '#a16207',
+  blue: '#1d4ed8',
+  magenta: '#a21caf',
+  cyan: '#0e7490',
+  white: '#e4e4e7',
+  brightBlack: '#52525b',
+  brightRed: '#dc2626',
+  brightGreen: '#166534',
+  brightYellow: '#b45309',
+  brightBlue: '#2563eb',
+  brightMagenta: '#c026d3',
+  brightCyan: '#155e75',
+  brightWhite: '#f4f4f5',
 } as const
 const DRACULA_THEME = {
   background: '#282a36',
@@ -143,7 +168,9 @@ const MIN_LIGHT_THEME = {
   black: '#212121',
   red: '#d32f2f',
   green: '#22863a',
-  yellow: '#ff9800',
+  // #ff9800 (Material orange 500) is 2.16:1 on white; darken the yellow
+  // slots to keep the author's amber intent while meeting WCAG AA (#97).
+  yellow: '#b45309',
   blue: '#1976d2',
   magenta: '#6f42c1',
   cyan: '#2b5581',
@@ -151,7 +178,7 @@ const MIN_LIGHT_THEME = {
   brightBlack: '#757575',
   brightRed: '#d32f2f',
   brightGreen: '#22863a',
-  brightYellow: '#ff9800',
+  brightYellow: '#b45309',
   brightBlue: '#1976d2',
   brightMagenta: '#6f42c1',
   brightCyan: '#2b5581',
@@ -194,4 +221,24 @@ export function getXtermTheme(theme: Theme) {
   if (theme === 'min-light') return MIN_LIGHT_THEME
   if (theme === 'dark-lemon') return DARK_LEMON_THEME
   return DARK_THEME
+}
+
+/**
+ * Whether a theme paints a light terminal background. Only these themes get
+ * the render-time contrast floor, so the ten dark themes stay byte-identical.
+ */
+export function isLightTerminalTheme(theme: Theme): boolean {
+  return theme === 'light' || theme === 'min-light'
+}
+
+/**
+ * xterm's `minimumContrastRatio` for a theme, or `undefined` to keep xterm's
+ * default (1). On light backgrounds even a correct palette cannot cover
+ * 256-color / truecolor output from agents (e.g. `\x1b[38;5;N`), and the
+ * white/brightWhite slots double as painted backgrounds, so we enforce a
+ * WCAG-AA floor of 4.5 at render time — the same approach VS Code ships by
+ * default. Dark themes are left untouched (#97).
+ */
+export function getMinimumContrastRatio(theme: Theme): number | undefined {
+  return isLightTerminalTheme(theme) ? 4.5 : undefined
 }


### PR DESCRIPTION
## What

Fixes #97 — terminal text is invisible on the light themes.

**Root cause:** `LIGHT_THEME` declared only `background`/`foreground`/`cursor`/`selectionBackground` and no ANSI colors, so xterm.js 5.5.0 fell back to the dark-oriented Tango palette painted onto `#fafafa`. Measured against `#fafafa`, 8 of 16 slots fail WCAG AA (4.5:1), five below 1.6:1 (brightWhite 1.11:1, brightYellow 1.19:1, white 1.40:1, brightCyan 1.53:1, brightGreen 1.55:1). `min-light` had `white`/`brightWhite` identical to its `#ffffff` background and yellows at 2.16:1.

**Fix (per the issue's two-layer proposal):**
1. **Real palettes.** `light` now ships a full 16-slot palette, every non-background slot ≥ 4.5:1 against `#fafafa`. `min-light` keeps its Material intent; only the yellow slots are darkened (`#ff9800` → `#b45309`, 5.02:1 on white).
2. **Render-time contrast floor.** `minimumContrastRatio: 4.5` is enabled **only** for light-background themes. `white`/`brightWhite` stay light (the issue's agreed trade-off — they double as `\x1b[47m`/`\x1b[107m` painted backgrounds, e.g. `less` status bars), and the floor darkens them when used as text. It also covers 256-color/truecolor output agents emit directly, which no 16-slot palette can. Dark themes are byte-identical (floor is xterm's default 1 for them).
3. **Docs.** `docs/THEMES.md` now states ANSI overrides are mandatory on a light background with 4.5:1 as the threshold, and documents the contrast-floor wiring, so the next light theme doesn't repeat this.

## How it was verified

- New `xtermThemes.test.ts` (7 tests): per-slot WCAG contrast ≥ 4.5:1 against the theme background for both light themes (white/brightWhite excluded by design and asserted to stay light), dark themes left byte-for-byte untouched (minimal four-key themes + pinned palette values for dracula/vscode/min-dark/dark-lemon/ember), and the floor helper scoped to light themes.
- Regression proven: reverting `yellow`/`brightGreen` to the old Tango fallbacks fails the contrast test at 2.40:1 / 1.55:1.
- `npx vitest run` — 231/231 pass (38 files). `npx tsc --noEmit` clean. Prettier clean on changed files. ESLint shows only the 6 pre-existing `no-empty` errors that are already on `main` (verified by stash).

Per the issue, I couldn't visually inspect the rendered terminal from here, but every changed slot is verified ≥ 4.5:1 against the theme background and the floor is wired at both construction (`useXtermSession.ts`) and theme-switch (`index.tsx`) time.

Closes #97
