### PR TITLE
fix: report onboarding CLI update failures instead of failing silently

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,14 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ### Fixed
 
+- The agent update button in onboarding no longer fails silently. It decided success purely by
+  checking whether the CLI binary was still on PATH, which is true even when the update itself
+  failed (network error, permission denied, ...), since the previous binary is still there. The
+  installer's real exit code is now checked first, and a failed update shows a toast instead of
+  quietly leaving the CLI on its old version. It also now catches the case where the installer
+  genuinely succeeds but a second, unmanaged install of the same CLI earlier on PATH shadows the
+  one that was just updated: if the resolved binary's version hasn't moved, the update is reported
+  as failed and the toast names the shadowing binary's path instead of reporting a false success.
 - A terminal that accepted keystrokes but rendered nothing — recoverable only by restarting it — now
   recovers on its own. Output is gated per PTY by a visibility flag, and the call that switches it
   back on was silently ignored whenever it landed while the session was spawning or restarting,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,7 @@ function ToastItem({ toast }: { toast: InAppToast }) {
       </div>
       <div className={styles.toastText}>
         <strong>{toast.title}</strong>
-        <span>{toast.body}</span>
+        <span title={toast.body}>{toast.body}</span>
       </div>
       <button
         type="button"

--- a/src/components/AgentInstall/AgentUpdateButton.tsx
+++ b/src/components/AgentInstall/AgentUpdateButton.tsx
@@ -6,10 +6,12 @@ import { installMethodsFor, type InstallToolchain } from '../../lib/agentInstall
 import { useT } from '../../lib/i18n'
 import { probeInstallToolchain } from '../../lib/tauri'
 import type { AgentType } from '../../lib/types'
+import { useUiStore } from '../../stores/uiStore'
 import styles from './agentActions.module.css'
 
 type Props = {
   agent: AgentType
+  label: string
   onUpdated?: () => void
 }
 
@@ -17,12 +19,13 @@ type Props = {
  * Re-runs the agent's own install command, which is how every package manager in the catalog
  * upgrades an existing install. Only offered where an update was actually detected.
  */
-export function AgentUpdateButton({ agent, onUpdated }: Props) {
+export function AgentUpdateButton({ agent, label, onUpdated }: Props) {
   const t = useT()
   const [toolchain, setToolchain] = useState<InstallToolchain | null>(null)
-  const { status, install } = useAgentInstall(agent)
+  const { status, shadowConflict, install } = useAgentInstall(agent)
   const busyAgent = useAgentOperationBusy()
-  const notifiedRef = useRef(false)
+  const pushToast = useUiStore((s) => s.pushToast)
+  const notifiedRef = useRef<'success' | 'failed' | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -37,10 +40,22 @@ export function AgentUpdateButton({ agent, onUpdated }: Props) {
   }, [])
 
   useEffect(() => {
-    if (status !== 'success' || notifiedRef.current) return
-    notifiedRef.current = true
-    onUpdated?.()
-  }, [status, onUpdated])
+    if (status === 'success') {
+      if (notifiedRef.current === 'success') return
+      notifiedRef.current = 'success'
+      onUpdated?.()
+    } else if (status === 'failed') {
+      if (notifiedRef.current === 'failed') return
+      notifiedRef.current = 'failed'
+      pushToast({
+        title: t('agentInstall.updateFailed'),
+        body: shadowConflict
+          ? t('agentInstall.updateFailedShadowed', { agent: label, path: shadowConflict.path })
+          : t('agentInstall.updateFailedBody', { agent: label }),
+        agent,
+      })
+    }
+  }, [status, shadowConflict, onUpdated, pushToast, t, label, agent])
 
   const method = installMethodsFor(agent, toolchain).find((entry) => entry.id === 'npm')
   if (!method) return null
@@ -52,7 +67,10 @@ export function AgentUpdateButton({ agent, onUpdated }: Props) {
       className={styles.quietBtn}
       disabled={running || (busyAgent !== null && busyAgent !== agent)}
       title={method.command}
-      onClick={() => void install(method)}
+      onClick={() => {
+        notifiedRef.current = null
+        void install(method)
+      }}
     >
       <ArrowUpCircle size={13} />
       {running ? t('agentInstall.installing') : t('onboarding.agentUpdateAction')}

--- a/src/components/modals/onboarding/AgentsStep.tsx
+++ b/src/components/modals/onboarding/AgentsStep.tsx
@@ -228,6 +228,7 @@ export function AgentsStep({
                         {row.outdated ? (
                           <AgentUpdateButton
                             agent={row.agent.id}
+                            label={row.agent.label}
                             onUpdated={() => onInstalled(row.agent.id)}
                           />
                         ) : null}

--- a/src/hooks/useAgentInstall.ts
+++ b/src/hooks/useAgentInstall.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from '
 
 import { installShellLine, type InstallMethod } from '../lib/agentInstall'
 import {
+  agentCliVersion,
   findCliLauncher,
   killPty,
   listenPtyData,
@@ -12,6 +13,14 @@ import {
 import { agentCliCommand, type AgentType } from '../lib/types'
 
 export type AgentInstallStatus = 'idle' | 'running' | 'success' | 'failed'
+
+/**
+ * Set only when a run finished with the installer reporting success and the resolver still
+ * finding a binary, but the version at that binary never moved — the installer likely updated a
+ * different install of the same CLI than the one PATH resolves to. Holds that binary's path so
+ * the caller can name it.
+ */
+export type AgentInstallShadowConflict = { path: string }
 
 const MAX_LOG_CHARS = 12_000
 const PROMPT_SETTLE_MS = 400
@@ -51,6 +60,7 @@ export function useAgentOperationBusy(): string | null {
 export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
   const [status, setStatus] = useState<AgentInstallStatus>('idle')
   const [log, setLog] = useState('')
+  const [shadowConflict, setShadowConflict] = useState<AgentInstallShadowConflict | null>(null)
   const ptyIdRef = useRef<string | null>(null)
   const cleanupRef = useRef<Array<() => void>>([])
   const disposedRef = useRef(false)
@@ -78,8 +88,14 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
       if (status === 'running' || busyAgent !== null) return
       teardown()
       setLog('')
+      setShadowConflict(null)
       setStatus('running')
       setBusyAgent(lockKey)
+
+      const command = method.verifyCommand ?? agentCliCommand(agent)
+      // Only meaningful for an update of something already on PATH — a fresh install has
+      // nothing to compare against, and verifyAbsent (uninstall) checks absence, not a version.
+      const beforeVersion = command && !method.verifyAbsent ? await agentCliVersion(command) : null
 
       const ptyId = `agent-install:${lockKey}:${Date.now()}`
       try {
@@ -99,21 +115,46 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
           }),
         )
         cleanupRef.current.push(
-          await listenPtyExit(spawned.id, () => {
+          await listenPtyExit(spawned.id, (payload) => {
             ptyIdRef.current = null
             if (busyAgent === lockKey) setBusyAgent(null)
-            const command = method.verifyCommand ?? agentCliCommand(agent)
+            // `installShellLine` ends the shell with a bare `exit`, which carries the
+            // installer command's own exit status. A non-zero code means the installer
+            // itself reported failure (network error, permission denied, ...) — trust it
+            // instead of falling through to the resolver, which would still find the
+            // previous binary on PATH and misreport the run as a success.
+            if (payload.code !== 0) {
+              setStatus('failed')
+              return
+            }
             if (!command) {
               setStatus('failed')
               return
             }
-            // The exit code of the shell says nothing about whether the binary
-            // landed somewhere we can launch it from, so ask the resolver.
+            // A zero exit code still doesn't confirm the binary landed somewhere we
+            // can launch it from, so ask the resolver.
             void findCliLauncher(command)
-              .then((found) => {
+              .then(async (found) => {
                 if (disposedRef.current) return
                 const worked = method.verifyAbsent ? !found : Boolean(found)
-                setStatus(worked ? 'success' : 'failed')
+                if (!worked) {
+                  setStatus('failed')
+                  return
+                }
+                // The resolver found a binary and the installer exited clean, but if that
+                // binary's version is exactly what it was before, the installer likely
+                // reached a different install of this CLI than the one PATH resolves to —
+                // a shadowing install earlier on PATH that the update never touched.
+                if (beforeVersion && found) {
+                  const afterVersion = await agentCliVersion(command)
+                  if (disposedRef.current) return
+                  if (afterVersion && afterVersion === beforeVersion) {
+                    setShadowConflict({ path: found })
+                    setStatus('failed')
+                    return
+                  }
+                }
+                setStatus('success')
               })
               .catch(() => {
                 if (!disposedRef.current) setStatus('failed')
@@ -136,8 +177,9 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
   const reset = useCallback(() => {
     teardown()
     setLog('')
+    setShadowConflict(null)
     setStatus('idle')
   }, [teardown])
 
-  return { status, log, install, reset }
+  return { status, log, shadowConflict, install, reset }
 }

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -214,6 +214,10 @@ export const en = {
   'agentInstall.uninstall': 'Uninstall',
   'agentInstall.uninstalling': 'Uninstalling…',
   'agentInstall.uninstallFailed': 'Uninstall did not complete',
+  'agentInstall.updateFailed': 'Update did not complete',
+  'agentInstall.updateFailedBody': '{agent} may still be on the previous version. Try again.',
+  'agentInstall.updateFailedShadowed':
+    '{agent} was reinstalled, but {path} is still the version on PATH.',
   'agentInstall.uninstallTitle': 'Uninstall {agent}',
   'agentInstall.uninstallConfirm':
     'This removes {agent} from this machine. Alethe will run the command below in a shell:',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -214,6 +214,10 @@ export const ptBR: Record<MessageKey, string> = {
   'agentInstall.uninstall': 'Desinstalar',
   'agentInstall.uninstalling': 'Desinstalando…',
   'agentInstall.uninstallFailed': 'A desinstalação não foi concluída',
+  'agentInstall.updateFailed': 'A atualização não foi concluída',
+  'agentInstall.updateFailedBody': '{agent} pode ainda estar na versão anterior. Tente novamente.',
+  'agentInstall.updateFailedShadowed':
+    '{agent} foi reinstalado, mas {path} continua sendo a versão no PATH.',
   'agentInstall.uninstallTitle': 'Desinstalar o {agent}',
   'agentInstall.uninstallConfirm':
     'Isto remove o {agent} desta máquina. O Alethe vai rodar o comando abaixo num shell:',


### PR DESCRIPTION
## Summary

- The onboarding agent update button decided success purely by checking whether the CLI binary was still resolvable on PATH after the run — never the installer's actual exit code, and never whether the version had actually changed.
- This misreported two real failure modes as success: the installer itself failing (network error, permission denied, ...), and a shadowing install of the same CLI earlier on PATH that the update never touched.
- The installer's exit code is now checked first, and a failed update surfaces a toast (with the specific reason when detectable) instead of silently reverting the button to "Update" with no explanation.

Fixes #103

## Test plan

- [x] `npm test` — 253/253 passing
- [x] `npm run build` (tsc + vite build) — clean
- [x] `npx tsc --noEmit` — clean
- [x] Reproduced the original bug locally with `@mimo-ai/cli` (native install shadowing the npm-managed one on PATH) and confirmed the update now reports failure with a toast naming the shadowing binary's path, instead of silently reverting with no feedback.