### PR TITLE
fix(sessions): resume panes running in a worktree

### DIFF
--- a/src-tauri/src/claude_sessions.rs
+++ b/src-tauri/src/claude_sessions.rs
@@ -24,12 +24,19 @@ pub struct ClaudeSessionSnapshot {
     pub size_bytes: u64,
 }
 
+/// Mirrors how Claude names the directory it stores a project's sessions in.
+///
+/// The dot matters. Worktrees live under `<repo>/.alethe/worktrees/<id>`, and
+/// Claude folds the dot into a hyphen along with the separators, writing
+/// `-home-user-repo--alethe-worktrees-<id>`. Leaving it as `.alethe` produced a
+/// path that never exists, so no session was ever found for a pane running in a
+/// worktree.
 fn encode_cwd_for_claude(cwd: &str) -> String {
     let trimmed = cwd.trim_end_matches(|c: char| c == '\\' || c == '/');
     trimmed
         .chars()
         .map(|c| match c {
-            ':' | '\\' | '/' => '-',
+            ':' | '\\' | '/' | '.' => '-',
             _ => c,
         })
         .collect()
@@ -671,5 +678,28 @@ mod tests {
         let header = serde_json::from_str::<RecordHeader>(line).unwrap();
         assert_eq!(header.entry_type.as_deref(), Some("user"));
         assert_eq!(first_text_block(line).as_deref(), Some("oi"));
+    }
+}
+
+#[cfg(test)]
+mod encode_cwd_tests {
+    use super::encode_cwd_for_claude;
+
+    #[test]
+    fn folds_the_dot_of_a_worktree_path() {
+        assert_eq!(
+            encode_cwd_for_claude("/home/user/repo/.alethe/worktrees/cl-a1b2c3"),
+            "-home-user-repo--alethe-worktrees-cl-a1b2c3"
+        );
+    }
+
+    #[test]
+    fn a_path_without_a_dot_is_unaffected() {
+        assert_eq!(encode_cwd_for_claude("/home/user/repo"), "-home-user-repo");
+    }
+
+    #[test]
+    fn trailing_separator_is_dropped() {
+        assert_eq!(encode_cwd_for_claude("/tmp/x/"), "-tmp-x");
     }
 }


### PR DESCRIPTION
## The bug

A pane created with `autoWorktree` never resumes. Reopening the app shows a fresh agent with the conversation gone, and the sidebar never picks up its title either. Panes in the repo root are unaffected — which makes it look like only the first session of a project breaks.

## Why

Both resume and automatic naming read the session directory Claude keeps per project, and `encode_cwd_for_claude` computes its name wrong. Claude folds a dot into a hyphen along with the path separators. Worktrees live under `<repo>/.alethe/worktrees/<id>`, so:

```
encode_cwd_for_claude  ->  -home-user-repo-.alethe-worktrees-cl-a1b2c3
Claude writes          ->  -home-user-repo--alethe-worktrees-cl-a1b2c3
```

The lookup points at a directory that never exists. `snapshot_claude_sessions` returns nothing, the pane never learns its real session id, and `--resume` gets an id with no transcript behind it. A new empty session is then created and saved over the pointer to the real conversation, so every reopen buries it further — the transcript is still on disk, just unreachable.

Only paths containing a dot are affected, which is why this reproduces reliably in worktrees and never in the repo root.

## The change

One character in the match arm, plus three tests covering a worktree path, a plain path, and a trailing separator.

## How I verified

Linux, Claude Code 2.1.233. Three panes with `autoWorktree` enabled, a conversation in each, close through the window button, reopen.

- Before: all three come back blank, `Ctx 0.0%`, no automatic name.
- After: all three resume with context restored, and automatic naming works again.

Also confirmed the session files were never lost — `~/.claude/projects/<encoded>/<id>.jsonl` had the full transcripts the whole time; the app was reading the wrong directory name.

Found while running several agents in worktrees on a fork. Happy to adjust anything.