### PR TITLE
test(git): isolate commit identity

### DIFF
--- a/src-tauri/src/git_control.rs
+++ b/src-tauri/src/git_control.rs
@@ -1069,6 +1069,11 @@ mod tests {
         root
     }
 
+    fn configure_test_git_identity(root: &Path) {
+        checked_output(root, &["config", "user.name", "Alethe Test"]).unwrap();
+        checked_output(root, &["config", "user.email", "alethe@example.invalid"]).unwrap();
+    }
+
     #[test]
     fn admin_lock_takes_precedence_and_is_never_retried() {
         let root = temp_dir("adminlock");
@@ -1113,6 +1118,7 @@ mod tests {
         let root = temp_dir("diff-unstaged");
         let root_string = root.to_string_lossy().into_owned();
         checked_output(&root, &["init"]).unwrap();
+        configure_test_git_identity(&root);
         fs::write(root.join("file.txt"), "line1\n").unwrap();
         checked_output(&root, &["add", "file.txt"]).unwrap();
         checked_output(&root, &["commit", "-m", "initial"]).unwrap();
@@ -1129,6 +1135,7 @@ mod tests {
         let root = temp_dir("diff-staged");
         let root_string = root.to_string_lossy().into_owned();
         checked_output(&root, &["init"]).unwrap();
+        configure_test_git_identity(&root);
         fs::write(root.join("file.txt"), "line1\n").unwrap();
         checked_output(&root, &["add", "file.txt"]).unwrap();
         checked_output(&root, &["commit", "-m", "initial"]).unwrap();
@@ -1149,6 +1156,7 @@ mod tests {
         let root = temp_dir("diff-binary");
         let root_string = root.to_string_lossy().into_owned();
         checked_output(&root, &["init"]).unwrap();
+        configure_test_git_identity(&root);
         fs::write(root.join("bin.dat"), &0u8.to_le_bytes()).unwrap();
         checked_output(&root, &["add", "bin.dat"]).unwrap();
         checked_output(&root, &["commit", "-m", "initial"]).unwrap();


### PR DESCRIPTION
## What changed

Configures a repository-local Git identity in the three `git_diff` tests that create an initial commit.

The tests previously inherited `user.name` and `user.email` from the machine running them. Clean Linux and Windows GitHub runners do not provide those values, so the commit failed before the behavior under test was reached.

This changes test setup only; production Git behavior is untouched.

## Reproduction and regression proof

With global/system Git configuration disabled:

```text
GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null cargo test --lib git_diff_
```

Before the fix:

- 3 failed
- 2 passed
- each failure was `Author identity unknown`

After the fix:

- 5 passed
- 0 failed

The test therefore reproduces the same isolation failure seen in the v1.6.0 Linux and Windows CI jobs and passes only after local test identity is configured.

## Full verification

Tested on Garuda Linux (x86_64):

- `cargo test --lib` — 226 passed, 1 ignored
- `npm test` — 42 files, 282 tests passed
- `npm run build` — passed
- `git diff --check` — passed
- touched Rust file formatted with `rustfmt`

Pre-existing Rust warnings and frontend dependency advisories are not changed by this test-only PR; the dependency advisories are addressed separately in #114.
