### PR TITLE
fix(privacy): make Discord presence opt-in

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -585,7 +585,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   gitControlPlacement: 'left',
   spotifyClientId: '',
   spotifyClientSecret: '',
-  discordRichPresenceEnabled: true,
+  discordRichPresenceEnabled: false,
   topbarShowClaudeUsage: true,
   topbarShowCodexUsage: true,
   topbarShowAntigravityUsage: true,

--- a/src/stores/projectsStore.migrations.test.ts
+++ b/src/stores/projectsStore.migrations.test.ts
@@ -36,6 +36,22 @@ describe('preference normalization', () => {
       automaticParkingOptIn: false,
     })
   })
+
+  it('keeps Discord Rich Presence opt-in while preserving an existing choice', () => {
+    expect(normalizePreferences(undefined).discordRichPresenceEnabled).toBe(false)
+    expect(
+      normalizePreferences({
+        ...DEFAULT_PREFERENCES,
+        discordRichPresenceEnabled: true,
+      }).discordRichPresenceEnabled,
+    ).toBe(true)
+    expect(
+      normalizePreferences({
+        ...DEFAULT_PREFERENCES,
+        discordRichPresenceEnabled: false,
+      }).discordRichPresenceEnabled,
+    ).toBe(false)
+  })
 })
 
 describe('projects file migration', () => {


### PR DESCRIPTION
Closes #118

## What changed

Makes Discord Rich Presence opt-in for fresh Alethe profiles by changing `discordRichPresenceEnabled` from `true` to `false` in default preferences.

Existing persisted choices are preserved:

- an existing `true` remains enabled
- an existing `false` remains disabled
- only a missing preference receives the safer disabled default

The existing Preferences → Integrations controls continue to let users enable or disable the integration explicitly.

This concerns generic Rich Presence through local Discord IPC; Alethe does not store a Discord bot/user token for this feature.

## Verification

Tested on Garuda Linux (x86_64):

- `npm test` — 42 files, 283 tests passed
- `npm run build` — passed
- targeted ESLint — passed
- targeted Prettier check for the changed test — passed
- `git diff --check` — passed

Regression-test sabotage:

- restored the old default of `true`
- the new migration/default test failed: expected fresh normalized preferences to be `false`, received `true`
- restored the opt-in default; the test and full suite passed

`src/lib/types.ts` is already flagged by the repository-wide formatting baseline. This PR changes one value in place and deliberately does not reformat that large shared file.
