### PR TITLE
fix(security): store GitHub Sync token in OS keyring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Changed
+
+- GitHub Gist Sync now stores its token in the operating system credential store. Existing plaintext
+  profile tokens migrate only after a verified keyring write and remain intact if migration fails.
+
 ## [1.6.0] — 2026-08-17
 
 ### Added

--- a/src-tauri/src/github_sync.rs
+++ b/src-tauri/src/github_sync.rs
@@ -3,7 +3,8 @@
 //
 // Config (token + id do gist + timestamps + login) persiste em
 
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -12,13 +13,26 @@ use tauri::AppHandle;
 
 use crate::paths::{activity_stats_file_path, app_data_dir, projects_file_path};
 use crate::provider_common::now_ms;
+use crate::secure_store::{OsSecretStore, SecretKind, SecretStore};
 
 const GIST_DESCRIPTION: &str = "Alethe sync — projects & activity (managed by the app)";
 const USER_AGENT: &str = "Alethe";
 const GITHUB_API: &str = "https://api.github.com";
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 struct SyncConfig {
+    #[serde(default)]
+    login: Option<String>,
+    #[serde(default)]
+    gist_id: Option<String>,
+    #[serde(default)]
+    last_push_ms: Option<u64>,
+    #[serde(default)]
+    last_pull_ms: Option<u64>,
+}
+
+#[derive(Default, Deserialize)]
+struct StoredSyncConfig {
     #[serde(default)]
     token: String,
     #[serde(default)]
@@ -29,6 +43,17 @@ struct SyncConfig {
     last_push_ms: Option<u64>,
     #[serde(default)]
     last_pull_ms: Option<u64>,
+}
+
+impl StoredSyncConfig {
+    fn metadata(&self) -> SyncConfig {
+        SyncConfig {
+            login: self.login.clone(),
+            gist_id: self.gist_id.clone(),
+            last_push_ms: self.last_push_ms,
+            last_pull_ms: self.last_pull_ms,
+        }
+    }
 }
 
 /// Snapshot enviado pro frontend. Nunca inclui o token.
@@ -46,28 +71,103 @@ fn config_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(app_data_dir(app)?.join("github_sync.json"))
 }
 
-fn load_config(app: &AppHandle) -> SyncConfig {
-    let Ok(path) = config_path(app) else {
-        return SyncConfig::default();
-    };
-    let Ok(raw) = fs::read_to_string(&path) else {
-        return SyncConfig::default();
-    };
-    serde_json::from_str(&raw).unwrap_or_default()
+fn active_profile_id(app: &AppHandle) -> Result<String, String> {
+    Ok(crate::profiles::ensure_profiles_index(app)?.active_profile_id)
 }
 
-fn save_config(app: &AppHandle, cfg: &SyncConfig) -> Result<(), String> {
-    let path = config_path(app)?;
+fn save_config_path(path: &Path, cfg: &SyncConfig) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let raw = serde_json::to_string_pretty(cfg).map_err(|e| e.to_string())?;
-    fs::write(&path, raw).map_err(|e| e.to_string())
+    let temp = path.with_extension(format!("json.{}.tmp", nanoid::nanoid!(10)));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temp).map_err(|e| e.to_string())?;
+    if let Err(error) = file.write_all(raw.as_bytes()).and_then(|_| file.sync_all()) {
+        let _ = fs::remove_file(&temp);
+        return Err(error.to_string());
+    }
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path).map_err(|e| e.to_string())?;
+    }
+    if let Err(error) = fs::rename(&temp, path) {
+        let _ = fs::remove_file(&temp);
+        return Err(error.to_string());
+    }
+    Ok(())
 }
 
-fn status_from(cfg: &SyncConfig) -> GithubSyncStatus {
+fn load_config_from(
+    path: &Path,
+    profile_id: &str,
+    store: &impl SecretStore,
+) -> Result<(SyncConfig, Option<String>), String> {
+    let stored = match fs::read_to_string(path) {
+        Ok(raw) => serde_json::from_str::<StoredSyncConfig>(&raw)
+            .map_err(|error| format!("invalid_sync_config: {error}"))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => StoredSyncConfig::default(),
+        Err(error) => return Err(error.to_string()),
+    };
+    let cfg = stored.metadata();
+    let mut token = store
+        .get(profile_id, SecretKind::GithubSyncToken)
+        .map_err(|error| error.to_string())?
+        .filter(|value| !value.trim().is_empty());
+
+    if !stored.token.trim().is_empty() {
+        if token.is_none() {
+            store
+                .set(profile_id, SecretKind::GithubSyncToken, &stored.token)
+                .map_err(|error| error.to_string())?;
+            let verified = store
+                .get(profile_id, SecretKind::GithubSyncToken)
+                .map_err(|error| error.to_string())?;
+            if verified.as_deref() != Some(stored.token.as_str()) {
+                return Err("secure_store_verification_failed".to_string());
+            }
+            token = verified;
+        }
+        save_config_path(path, &cfg)?;
+    }
+
+    Ok((cfg, token.filter(|value| !value.trim().is_empty())))
+}
+
+fn load_config(app: &AppHandle) -> Result<(SyncConfig, Option<String>, String), String> {
+    let profile_id = active_profile_id(app)?;
+    let (cfg, token) = load_config_from(&config_path(app)?, &profile_id, &OsSecretStore)?;
+    Ok((cfg, token, profile_id))
+}
+
+fn save_config(app: &AppHandle, cfg: &SyncConfig) -> Result<(), String> {
+    save_config_path(&config_path(app)?, cfg)
+}
+
+fn restore_token(
+    store: &impl SecretStore,
+    profile_id: &str,
+    previous: Option<&str>,
+) -> Result<(), String> {
+    match previous {
+        Some(value) => store
+            .set(profile_id, SecretKind::GithubSyncToken, value)
+            .map_err(|error| error.to_string()),
+        None => store
+            .delete(profile_id, SecretKind::GithubSyncToken)
+            .map_err(|error| error.to_string()),
+    }
+}
+
+fn status_from(cfg: &SyncConfig, connected: bool) -> GithubSyncStatus {
     GithubSyncStatus {
-        connected: !cfg.token.trim().is_empty(),
+        connected,
         login: cfg.login.clone(),
         gist_id: cfg.gist_id.clone(),
         gist_url: cfg
@@ -183,7 +283,8 @@ async fn gist_file_content(
 
 #[tauri::command]
 pub fn github_sync_status(app: AppHandle) -> Result<GithubSyncStatus, String> {
-    Ok(status_from(&load_config(&app)))
+    let (cfg, token, _) = load_config(&app)?;
+    Ok(status_from(&cfg, token.is_some()))
 }
 
 #[tauri::command]
@@ -212,29 +313,46 @@ pub async fn github_sync_set_token(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let mut cfg = load_config(&app);
-    cfg.token = token;
+    let (mut cfg, previous_token, profile_id) = load_config(&app)?;
+    let store = OsSecretStore;
+    store
+        .set(&profile_id, SecretKind::GithubSyncToken, &token)
+        .map_err(|error| error.to_string())?;
+    let verified = store
+        .get(&profile_id, SecretKind::GithubSyncToken)
+        .map_err(|error| error.to_string())?;
+    if verified.as_deref() != Some(token.as_str()) {
+        if restore_token(&store, &profile_id, previous_token.as_deref()).is_err() {
+            return Err("secure_store_verification_and_rollback_failed".to_string());
+        }
+        return Err("secure_store_verification_failed".to_string());
+    }
     cfg.login = login;
-    save_config(&app, &cfg)?;
-    Ok(status_from(&cfg))
+    if let Err(error) = save_config(&app, &cfg) {
+        if restore_token(&store, &profile_id, previous_token.as_deref()).is_err() {
+            return Err(format!("{error}; secure_store_rollback_failed"));
+        }
+        return Err(error);
+    }
+    Ok(status_from(&cfg, true))
 }
 
 #[tauri::command]
 pub fn github_sync_logout(app: AppHandle) -> Result<GithubSyncStatus, String> {
-    let mut cfg = load_config(&app);
-    cfg.token = String::new();
+    let (mut cfg, _, profile_id) = load_config(&app)?;
+    OsSecretStore
+        .delete(&profile_id, SecretKind::GithubSyncToken)
+        .map_err(|error| error.to_string())?;
     cfg.login = None;
     save_config(&app, &cfg)?;
-    Ok(status_from(&cfg))
+    Ok(status_from(&cfg, false))
 }
 
 /// guardado sumiu (404/422), recria.
 #[tauri::command]
 pub async fn github_sync_push(app: AppHandle) -> Result<GithubSyncStatus, String> {
-    let mut cfg = load_config(&app);
-    if cfg.token.trim().is_empty() {
-        return Err("not_connected".to_string());
-    }
+    let (mut cfg, token, _) = load_config(&app)?;
+    let token = token.ok_or_else(|| "not_connected".to_string())?;
     let files = collect_files(&app)?;
     if files.is_empty() {
         return Err("nothing_to_sync".to_string());
@@ -244,7 +362,7 @@ pub async fn github_sync_push(app: AppHandle) -> Result<GithubSyncStatus, String
 
     let mut new_id: Option<String> = None;
     if let Some(id) = cfg.gist_id.clone() {
-        let resp = auth(client.patch(format!("{GITHUB_API}/gists/{id}")), &cfg.token)
+        let resp = auth(client.patch(format!("{GITHUB_API}/gists/{id}")), &token)
             .json(&body)
             .send()
             .await
@@ -252,13 +370,13 @@ pub async fn github_sync_push(app: AppHandle) -> Result<GithubSyncStatus, String
         let code = resp.status().as_u16();
         if !resp.status().is_success() {
             if code == 404 || code == 422 {
-                new_id = Some(create_gist(&client, &cfg.token, &body).await?);
+                new_id = Some(create_gist(&client, &token, &body).await?);
             } else {
                 return Err(format!("github returned {}", resp.status()));
             }
         }
     } else {
-        new_id = Some(create_gist(&client, &cfg.token, &body).await?);
+        new_id = Some(create_gist(&client, &token, &body).await?);
     }
 
     if let Some(id) = new_id {
@@ -266,20 +384,18 @@ pub async fn github_sync_push(app: AppHandle) -> Result<GithubSyncStatus, String
     }
     cfg.last_push_ms = Some(now_ms());
     save_config(&app, &cfg)?;
-    Ok(status_from(&cfg))
+    Ok(status_from(&cfg, true))
 }
 
 #[tauri::command]
 pub async fn github_sync_pull(app: AppHandle) -> Result<GithubSyncStatus, String> {
-    let mut cfg = load_config(&app);
-    if cfg.token.trim().is_empty() {
-        return Err("not_connected".to_string());
-    }
+    let (mut cfg, token, _) = load_config(&app)?;
+    let token = token.ok_or_else(|| "not_connected".to_string())?;
     let Some(id) = cfg.gist_id.clone() else {
         return Err("no_remote".to_string());
     };
     let client = reqwest::Client::new();
-    let resp = auth(client.get(format!("{GITHUB_API}/gists/{id}")), &cfg.token)
+    let resp = auth(client.get(format!("{GITHUB_API}/gists/{id}")), &token)
         .send()
         .await
         .map_err(|e| format!("request failed: {e}"))?;
@@ -295,18 +411,204 @@ pub async fn github_sync_pull(app: AppHandle) -> Result<GithubSyncStatus, String
         .and_then(|f| f.as_object())
         .ok_or_else(|| "malformed gist".to_string())?;
 
-    if let Some(content) = gist_file_content(&client, &cfg.token, files, "projects.json").await? {
+    if let Some(content) = gist_file_content(&client, &token, files, "projects.json").await? {
         write_atomic(&projects_file_path(&app)?, &content)?;
     } else {
         return Err("remote_missing_projects".to_string());
     }
-    if let Some(content) =
-        gist_file_content(&client, &cfg.token, files, "activity-stats.json").await?
-    {
+    if let Some(content) = gist_file_content(&client, &token, files, "activity-stats.json").await? {
         write_atomic(&activity_stats_file_path(&app)?, &content)?;
     }
 
     cfg.last_pull_ms = Some(now_ms());
     save_config(&app, &cfg)?;
-    Ok(status_from(&cfg))
+    Ok(status_from(&cfg, true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secure_store::SecureStoreError;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Default)]
+    struct FakeStore {
+        values: Mutex<HashMap<String, String>>,
+        fail_set: bool,
+    }
+
+    impl FakeStore {
+        fn key(profile_id: &str, kind: SecretKind) -> String {
+            let suffix = match kind {
+                SecretKind::GithubSyncToken => "github",
+            };
+            format!("{profile_id}:{suffix}")
+        }
+
+        fn with_token(profile_id: &str, token: &str) -> Self {
+            let mut values = HashMap::new();
+            values.insert(
+                Self::key(profile_id, SecretKind::GithubSyncToken),
+                token.to_string(),
+            );
+            Self {
+                values: Mutex::new(values),
+                fail_set: false,
+            }
+        }
+    }
+
+    impl SecretStore for FakeStore {
+        fn get(
+            &self,
+            profile_id: &str,
+            kind: SecretKind,
+        ) -> Result<Option<String>, SecureStoreError> {
+            Ok(self
+                .values
+                .lock()
+                .unwrap()
+                .get(&Self::key(profile_id, kind))
+                .cloned())
+        }
+
+        fn set(
+            &self,
+            profile_id: &str,
+            kind: SecretKind,
+            value: &str,
+        ) -> Result<(), SecureStoreError> {
+            if self.fail_set {
+                return Err(SecureStoreError::Unavailable("locked".to_string()));
+            }
+            self.values
+                .lock()
+                .unwrap()
+                .insert(Self::key(profile_id, kind), value.to_string());
+            Ok(())
+        }
+
+        fn delete(&self, profile_id: &str, kind: SecretKind) -> Result<(), SecureStoreError> {
+            self.values
+                .lock()
+                .unwrap()
+                .remove(&Self::key(profile_id, kind));
+            Ok(())
+        }
+    }
+
+    fn temp_config(label: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "alethe-github-sync-{label}-{}-{suffix}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&directory).unwrap();
+        directory.join("github_sync.json")
+    }
+
+    #[test]
+    fn migrates_plaintext_token_only_after_keyring_verification() {
+        let path = temp_config("migrate");
+        let legacy_token = "legacy-secret-value";
+        fs::write(
+            &path,
+            format!(
+                r#"{{"token":"{legacy_token}","login":"octocat","gist_id":"gist-1","last_push_ms":7}}"#
+            ),
+        )
+        .unwrap();
+        let store = FakeStore::default();
+
+        let (config, token) = load_config_from(&path, "profile-a", &store).unwrap();
+
+        assert_eq!(token.as_deref(), Some(legacy_token));
+        assert_eq!(config.login.as_deref(), Some("octocat"));
+        assert_eq!(config.gist_id.as_deref(), Some("gist-1"));
+        assert_eq!(config.last_push_ms, Some(7));
+        let rewritten: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(rewritten.get("token").is_none());
+        assert!(!fs::read_to_string(&path).unwrap().contains(legacy_token));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn existing_keyring_token_wins_and_stale_plaintext_is_scrubbed() {
+        let path = temp_config("existing");
+        fs::write(
+            &path,
+            r#"{"token":"stale-plaintext","login":"octocat","gist_id":"gist-1"}"#,
+        )
+        .unwrap();
+        let store = FakeStore::with_token("profile-a", "keyring-token");
+
+        let (_, token) = load_config_from(&path, "profile-a", &store).unwrap();
+
+        assert_eq!(token.as_deref(), Some("keyring-token"));
+        let rewritten = fs::read_to_string(&path).unwrap();
+        assert!(!rewritten.contains("stale-plaintext"));
+        assert!(!rewritten.contains("keyring-token"));
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn empty_keyring_entry_does_not_replace_a_legacy_token() {
+        let path = temp_config("empty-keyring");
+        fs::write(&path, r#"{"token":"legacy-token"}"#).unwrap();
+        let store = FakeStore::with_token("profile-a", "");
+
+        let (_, token) = load_config_from(&path, "profile-a", &store).unwrap();
+
+        assert_eq!(token.as_deref(), Some("legacy-token"));
+        assert!(!fs::read_to_string(&path).unwrap().contains("legacy-token"));
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn failed_keyring_migration_preserves_the_legacy_file() {
+        let path = temp_config("failure");
+        let original = r#"{"token":"only-copy","login":"octocat"}"#;
+        fs::write(&path, original).unwrap();
+        let store = FakeStore {
+            values: Mutex::new(HashMap::new()),
+            fail_set: true,
+        };
+
+        let error = load_config_from(&path, "profile-a", &store).unwrap_err();
+
+        assert!(error.starts_with("secure_store_unavailable:"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn migration_is_profile_scoped_and_idempotent() {
+        let path = temp_config("idempotent");
+        fs::write(&path, r#"{"token":"profile-a-token"}"#).unwrap();
+        let store = FakeStore::default();
+
+        let (_, first) = load_config_from(&path, "profile-a", &store).unwrap();
+        let (_, second) = load_config_from(&path, "profile-a", &store).unwrap();
+        let (_, other) = load_config_from(&path, "profile-b", &store).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.as_deref(), Some("profile-a-token"));
+        assert!(other.is_none());
+        let _ = fs::remove_dir_all(path.parent().unwrap());
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ mod remote;
 mod resource_manager;
 mod resources;
 mod scheduler;
+mod secure_store;
 mod session_watcher;
 mod skills;
 mod spotify;

--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -479,6 +479,9 @@ pub fn delete_profile_state(app: &AppHandle, profile_id: &str) -> Result<Profile
         .cloned()
         .ok_or_else(|| format!("profile not found: {profile_id}"))?;
     let target_dir = profile_dir(&root, &target.id);
+    if target_dir.join("github_sync.json").is_file() {
+        crate::secure_store::delete_github_sync_token(&target.id)?;
+    }
     if target_dir.exists() {
         fs::remove_dir_all(&target_dir).map_err(|error| error.to_string())?;
     }

--- a/src-tauri/src/secure_store.rs
+++ b/src-tauri/src/secure_store.rs
@@ -1,0 +1,92 @@
+use std::fmt;
+
+const SERVICE: &str = "com.kc1t.alethe";
+
+#[derive(Clone, Copy)]
+pub enum SecretKind {
+    GithubSyncToken,
+}
+
+impl SecretKind {
+    fn suffix(self) -> &'static str {
+        match self {
+            Self::GithubSyncToken => "github-sync-token",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SecureStoreError {
+    Unavailable(String),
+}
+
+impl fmt::Display for SecureStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable(message) => write!(formatter, "secure_store_unavailable: {message}"),
+        }
+    }
+}
+
+pub trait SecretStore {
+    fn get(&self, profile_id: &str, kind: SecretKind) -> Result<Option<String>, SecureStoreError>;
+    fn set(&self, profile_id: &str, kind: SecretKind, value: &str) -> Result<(), SecureStoreError>;
+    fn delete(&self, profile_id: &str, kind: SecretKind) -> Result<(), SecureStoreError>;
+}
+
+pub struct OsSecretStore;
+
+fn account(profile_id: &str, kind: SecretKind) -> String {
+    format!("profile:{profile_id}:{}", kind.suffix())
+}
+
+fn entry(profile_id: &str, kind: SecretKind) -> Result<keyring::Entry, SecureStoreError> {
+    keyring::Entry::new(SERVICE, &account(profile_id, kind))
+        .map_err(|error| SecureStoreError::Unavailable(error.to_string()))
+}
+
+impl SecretStore for OsSecretStore {
+    fn get(&self, profile_id: &str, kind: SecretKind) -> Result<Option<String>, SecureStoreError> {
+        match entry(profile_id, kind)?.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(SecureStoreError::Unavailable(error.to_string())),
+        }
+    }
+
+    fn set(&self, profile_id: &str, kind: SecretKind, value: &str) -> Result<(), SecureStoreError> {
+        entry(profile_id, kind)?
+            .set_password(value)
+            .map_err(|error| SecureStoreError::Unavailable(error.to_string()))
+    }
+
+    fn delete(&self, profile_id: &str, kind: SecretKind) -> Result<(), SecureStoreError> {
+        match entry(profile_id, kind)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(SecureStoreError::Unavailable(error.to_string())),
+        }
+    }
+}
+
+pub fn delete_github_sync_token(profile_id: &str) -> Result<(), String> {
+    OsSecretStore
+        .delete(profile_id, SecretKind::GithubSyncToken)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_accounts_are_stable_and_isolated() {
+        assert_eq!(
+            account("default", SecretKind::GithubSyncToken),
+            "profile:default:github-sync-token"
+        );
+        assert_ne!(
+            account("profile-a", SecretKind::GithubSyncToken),
+            account("profile-b", SecretKind::GithubSyncToken)
+        );
+    }
+}


### PR DESCRIPTION
Closes #124

## What changed

Moves GitHub Gist Sync's personal access token out of profile JSON and into the existing cross-platform OS credential-store dependency:

- Linux: Secret Service / KWallet-compatible backend
- macOS: Keychain
- Windows: Credential Manager

Adds a small profile-scoped `secure_store` abstraction using:

- service: `com.kc1t.alethe`
- account: `profile:{profile_id}:github-sync-token`

`github_sync.json` now serializes only non-secret login, Gist ID, and timestamp metadata.

## Failure-safe migration

On first config load:

1. Read the profile's keyring entry.
2. If a legacy plaintext token exists and the keyring is empty, write it to keyring.
3. Read it back and verify exact equality.
4. Only then atomically rewrite `github_sync.json` without the token.

Additional behavior:

- an existing keyring value wins over a stale plaintext copy;
- an empty keyring entry does not overwrite/destroy a valid legacy token;
- a locked/unavailable store returns an explicit error and leaves the legacy file unchanged;
- token replacement rolls back the previous keyring value if metadata save fails;
- logout deletes the keyring entry;
- profile deletion removes the GitHub entry when that profile has GitHub Sync metadata;
- secret values are not included in status payloads, errors, or debug types.

Tests use an in-memory fake store and never access the developer's real keyring.

## Verification

Tested on Garuda Linux (x86_64):

- `cargo test --lib` — 231 passed, 1 ignored
- focused GitHub migration tests — 5 passed
- secure-store naming/isolation test — passed
- `npm test` — 42 files, 282 tests passed
- `npm run build` — passed
- `git diff --check` — passed
- changed Rust files formatted with `rustfmt`

Regression-test sabotage:

- temporarily disabled the plaintext-scrubbing metadata rewrite after a successful keyring write;
- `migrates_plaintext_token_only_after_keyring_verification` failed because the JSON still contained `token`;
- restored the rewrite; focused and full tests passed.

The repository still emits pre-existing Rust warnings and the original frontend lockfile still reports the advisories addressed separately in #114.

## Manual verification deliberately not performed

I did not connect a real GitHub token or mutate the developer's live KWallet/Secret Service entries. Cross-platform native keyring smoke tests should be run by maintainers/release CI on disposable profiles before release.
