### PR TITLE
ci: gate releases on the full quality suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 # Cancela runs antigos do mesmo branch/PR quando um novo chega.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  quality:
+    uses: ./.github/workflows/ci.yml
+
   build:
     name: Build ${{ matrix.label }}
+    needs: quality
     permissions:
       contents: write
     strategy:

--- a/src/lib/releaseWorkflow.test.ts
+++ b/src/lib/releaseWorkflow.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
+const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8')
+
+function jobBlocks(workflow: string): string[] {
+  const lines = workflow.split('\n')
+  const jobsIndex = lines.findIndex((line) => line === 'jobs:')
+  const blocks: string[] = []
+  let current: string[] | null = null
+
+  for (const line of lines.slice(jobsIndex + 1)) {
+    if (/^\s{2}[A-Za-z0-9_-]+:$/.test(line)) {
+      if (current) blocks.push(current.join('\n'))
+      current = [line]
+    } else if (current) {
+      current.push(line)
+    }
+  }
+
+  if (current) blocks.push(current.join('\n'))
+  return blocks
+}
+
+describe('release workflow quality gate', () => {
+  it('keeps CI event triggers while allowing release to call it', () => {
+    expect(ciWorkflow).toMatch(/^\s{2}push:$/m)
+    expect(ciWorkflow).toMatch(/^\s{2}pull_request:$/m)
+    expect(ciWorkflow).toMatch(/^\s{2}workflow_call:$/m)
+  })
+
+  it('gates every Tauri publishing job on the reusable CI workflow', () => {
+    const blocks = jobBlocks(releaseWorkflow)
+    const qualityJob = blocks.find((block) => block.startsWith('  quality:'))
+    const publishingJobs = blocks.filter((block) => block.includes('tauri-apps/tauri-action'))
+
+    expect(qualityJob).toContain('uses: ./.github/workflows/ci.yml')
+    expect(publishingJobs).not.toHaveLength(0)
+
+    for (const job of publishingJobs) {
+      expect(job).toMatch(/^\s{4}needs: quality$/m)
+      expect(job).toMatch(/^\s{4}permissions:\n\s{6}contents: write$/m)
+      expect(job).toContain('secrets.GITHUB_TOKEN')
+      expect(job).toContain('secrets.TAURI_SIGNING_PRIVATE_KEY')
+      expect(job).toContain('secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD')
+    }
+
+    for (const job of blocks.filter((block) => !publishingJobs.includes(block))) {
+      expect(job).not.toContain('permissions:')
+      expect(job).not.toContain('secrets.')
+    }
+  })
+})


### PR DESCRIPTION
Closes #122

## What changed

Makes the normal CI workflow reusable and requires it before release publishing:

- adds `workflow_call` to `.github/workflows/ci.yml` while preserving push and pull-request triggers;
- adds a release `quality` job that calls the same CI workflow;
- makes the Tauri build/publish matrix depend on `quality`;
- leaves write permission and signing/release secrets scoped to the publishing job.

This prevents a manually dispatched release from publishing artifacts while the repository's frontend or cross-platform Rust suite is red.

Action pinning and unrelated workflow cleanup are intentionally excluded.

## Verification

Tested on Garuda Linux:

- release workflow regression test — 2 passed
- full frontend suite — 43 files, 284 tests passed
- `npm run build` — passed
- targeted Prettier check — passed
- targeted ESLint — passed
- `git diff --check` — passed

Regression sabotage:

- temporarily removed `needs: quality` from the publishing job;
- the new workflow test failed on that exact missing dependency;
- restored the gate; targeted and full tests passed.

The static test also verifies that non-publishing jobs do not receive release permissions or secrets.
