### PR TITLE
fix(security): remove pipe-to-shell agent installers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Security
+
+- Removed install options that downloaded mutable vendor scripts and executed them directly through
+  a shell. Safe package-manager options and links to each vendor's installation documentation remain
+  available.
+
 ## [1.6.0] — 2026-08-17
 
 ### Added

--- a/src/lib/agentInstall.test.ts
+++ b/src/lib/agentInstall.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  AGENT_INSTALL_CATALOG,
   installMethodsFor,
   installShellLine,
   type InstallToolchain,
@@ -19,21 +20,19 @@ const BARE: InstallToolchain = {
 }
 
 describe('installMethodsFor', () => {
-  it('offers the native installer first even when npm is available', () => {
+  it('offers only package-manager installers for Claude', () => {
     const methods = installMethodsFor('claude', { ...BARE, node: 'v22.3.0', npm: true })
-    expect(methods.map((method) => method.id)).toEqual(['native', 'npm'])
-    expect(methods[0].command).toContain('claude.ai/install.ps1')
+    expect(methods.map((method) => method.id)).toEqual(['npm'])
   })
 
   it('hides npm when the machine has no npm', () => {
     const methods = installMethodsFor('codex', BARE)
-    expect(methods.map((method) => method.id)).toEqual(['native'])
+    expect(methods).toEqual([])
   })
 
   it('surfaces winget for Claude only when winget exists', () => {
-    expect(installMethodsFor('claude', BARE).map((m) => m.id)).toEqual(['native'])
+    expect(installMethodsFor('claude', BARE)).toEqual([])
     expect(installMethodsFor('claude', { ...BARE, winget: true }).map((m) => m.id)).toEqual([
-      'native',
       'winget',
     ])
   })
@@ -58,14 +57,35 @@ describe('installMethodsFor', () => {
 
   it('treats a missing toolchain probe as "only requirement-free methods"', () => {
     expect(installMethodsFor('opencode', null)).toEqual([])
-    expect(installMethodsFor('antigravity', null).map((m) => m.id)).toEqual(['native'])
+    expect(installMethodsFor('antigravity', null)).toEqual([])
   })
 
-  it('installs Freebuff through npm and Mimo through its own script', () => {
+  it('installs Freebuff and Mimo through npm', () => {
     expect(installMethodsFor('freebuff', { ...BARE, npm: true })[0].command).toBe(
       'npm install -g freebuff',
     )
-    expect(installMethodsFor('mimo', BARE).map((method) => method.id)).toEqual(['native'])
+    expect(installMethodsFor('mimo', BARE)).toEqual([])
+    expect(installMethodsFor('mimo', { ...BARE, npm: true })[0].command).toBe(
+      'npm install -g @mimo-ai/cli',
+    )
+  })
+})
+
+describe('AGENT_INSTALL_CATALOG security', () => {
+  const commands = Object.values(AGENT_INSTALL_CATALOG).flatMap((entry) =>
+    entry.methods.map((method) => method.command),
+  )
+
+  it('contains no pipe-to-shell constructs', () => {
+    const shellPipeOrExpressionExecution = /\||\b(?:iex|invoke-expression)\b/i
+
+    expect(commands.filter((command) => shellPipeOrExpressionExecution.test(command))).toEqual([])
+  })
+
+  it('contains no mutable remote script URLs', () => {
+    const remoteUrl = /https?:\/\//i
+
+    expect(commands.filter((command) => remoteUrl.test(command))).toEqual([])
   })
 })
 
@@ -75,9 +95,9 @@ describe('needsNodeToolchain', () => {
     expect(needsNodeToolchain('freebuff', { ...BARE, npm: true })).toBe(false)
   })
 
-  it('stays quiet when the agent has a installer that does not need Node', () => {
-    expect(needsNodeToolchain('claude', BARE)).toBe(false)
-    expect(needsNodeToolchain('mimo', BARE)).toBe(false)
+  it('flags agents whose remaining safe method needs Node', () => {
+    expect(needsNodeToolchain('claude', BARE)).toBe(true)
+    expect(needsNodeToolchain('mimo', BARE)).toBe(true)
   })
 
   it('stays quiet for agents with no installer at all', () => {
@@ -103,7 +123,7 @@ describe('uninstallMethodsFor', () => {
     )
   })
 
-  it('never offers to undo a native install script', () => {
+  it('returns nothing when no package-manager install is available', () => {
     expect(uninstallMethodsFor('antigravity', { ...BARE, npm: true })).toEqual([])
     expect(uninstallMethodsFor('claude', BARE)).toEqual([])
   })
@@ -120,6 +140,8 @@ describe('uninstallMethodsFor', () => {
 
 describe('installShellLine', () => {
   it('closes the shell so the runner can detect completion', () => {
-    expect(installShellLine('npm install -g opencode-ai')).toBe('npm install -g opencode-ai; exit\r')
+    expect(installShellLine('npm install -g opencode-ai')).toBe(
+      'npm install -g opencode-ai; exit\r',
+    )
   })
 })

--- a/src/lib/agentInstall.ts
+++ b/src/lib/agentInstall.ts
@@ -40,17 +40,13 @@ export const AGENT_INSTALL_CATALOG: Partial<Record<AgentType, AgentInstallCatalo
   claude: {
     docsUrl: 'https://code.claude.com/docs/en/setup',
     methods: [
-      { id: 'native', command: 'irm https://claude.ai/install.ps1 | iex' },
       { id: 'winget', command: 'winget install Anthropic.ClaudeCode', requires: 'winget' },
       { id: 'npm', command: 'npm install -g @anthropic-ai/claude-code', requires: 'npm' },
     ],
   },
   codex: {
     docsUrl: 'https://github.com/openai/codex',
-    methods: [
-      { id: 'native', command: 'irm https://chatgpt.com/codex/install.ps1 | iex' },
-      { id: 'npm', command: 'npm install -g @openai/codex', requires: 'npm' },
-    ],
+    methods: [{ id: 'npm', command: 'npm install -g @openai/codex', requires: 'npm' }],
   },
   copilot: {
     docsUrl: 'https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started',
@@ -61,14 +57,11 @@ export const AGENT_INSTALL_CATALOG: Partial<Record<AgentType, AgentInstallCatalo
   },
   antigravity: {
     docsUrl: 'https://antigravity.google/docs/cli/install',
-    methods: [{ id: 'native', command: 'irm https://antigravity.google/cli/install.ps1 | iex' }],
+    methods: [],
   },
   mimo: {
     docsUrl: 'https://github.com/XiaomiMiMo/MiMo-Code',
-    methods: [
-      { id: 'native', command: 'irm https://mimo.xiaomi.com/install.ps1 | iex' },
-      { id: 'npm', command: 'npm install -g @mimo-ai/cli', requires: 'npm' },
-    ],
+    methods: [{ id: 'npm', command: 'npm install -g @mimo-ai/cli', requires: 'npm' }],
   },
   freebuff: {
     docsUrl: 'https://freebuff.com',
@@ -122,7 +115,7 @@ const NODE_INSTALL_METHODS: InstallMethod[] = [
 
 /**
  * True when the agent would be installable here if Node were present: it has installers, but every
- * one of them needs npm and npm is missing. Agents with a native installer never qualify.
+ * one of them needs npm and npm is missing.
  */
 export function needsNodeToolchain(agent: AgentType, toolchain: InstallToolchain | null): boolean {
   const entry = AGENT_INSTALL_CATALOG[agent]
@@ -149,9 +142,8 @@ const UNINSTALL_TEMPLATE: Partial<Record<InstallMethodId, (target: string) => st
 }
 
 /**
- * How this agent can be removed on this machine, best first. `native` installers are skipped: none
- * of the vendors documents an uninstall for their install script, and guessing would delete the
- * wrong thing. An empty list means "we cannot remove it for you".
+ * How this agent can be removed on this machine, best first. An empty list means "we cannot remove
+ * it for you".
  */
 export function uninstallMethodsFor(
   agent: AgentType,


### PR DESCRIPTION
Closes #123

## What changed

Removes built-in agent install methods that downloaded mutable PowerShell scripts and executed them directly through `iex` / `Invoke-Expression`.

Safe catalog behavior remains:

- Claude: Winget and npm
- Codex: npm
- Mimo: npm
- existing safe package-manager methods for the other agents
- vendor documentation links remain available when no safe automatic method exists

Antigravity now falls back to its documentation instead of executing a remote script.

This is the immediate catalog hardening only. Replacing the shell-string executor with a typed executable-plus-argv backend remains a separate follow-up.

## Verification

Tested on Garuda Linux:

- focused installer suite — 19 passed
- full frontend suite — 42 files, 284 tests passed
- `npm run build` — passed
- targeted Prettier check — passed
- targeted ESLint — passed
- `git diff --check` — passed

New catalog assertions reject:

- shell pipes;
- `iex` and `Invoke-Expression`;
- remote URLs inside executable installer commands.

Regression sabotage:

- temporarily restored the Claude pipe-to-PowerShell installer;
- five tests failed, including both supply-chain assertions and safe-method selection behavior;
- removed it again; focused and full suites passed.
