### PR TITLE
fix(privacy): make provider usage polling opt-in

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Changed
+
+- Claude Code, Codex, and Antigravity topbar usage polling is now opt-in. Enabling an indicator may
+  use existing provider or CLI credentials and contact provider services.
+
 ## [1.6.0] — 2026-08-17
 
 ### Added

--- a/src/components/TitleBar/index.test.tsx
+++ b/src/components/TitleBar/index.test.tsx
@@ -1,0 +1,156 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getCachedClaudeUsage: vi.fn(),
+  getCachedCodexUsage: vi.fn(),
+  getCachedAntigravityUsage: vi.fn(),
+  remoteControlConnectedDevices: vi.fn().mockResolvedValue(0),
+  onFocusChanged: vi.fn().mockResolvedValue(() => undefined),
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    minimize: vi.fn(),
+    toggleMaximize: vi.fn(),
+    setTitle: vi.fn(),
+    onFocusChanged: mocks.onFocusChanged,
+  }),
+}))
+vi.mock('../../lib/claudeUsageCache', () => ({
+  getCachedClaudeUsage: mocks.getCachedClaudeUsage,
+}))
+vi.mock('../../lib/codexUsageCache', () => ({
+  getCachedCodexUsage: mocks.getCachedCodexUsage,
+}))
+vi.mock('../../lib/antigravityUsageCache', () => ({
+  getCachedAntigravityUsage: mocks.getCachedAntigravityUsage,
+}))
+vi.mock('../../lib/limitResetWatch', () => ({
+  observeClaudeReset: vi.fn(),
+  observeCodexReset: vi.fn(),
+}))
+vi.mock('../../hooks/useCloseConfirmation', () => ({ requestAppClose: vi.fn() }))
+vi.mock('../../lib/tauri', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/tauri')>()),
+  killPty: vi.fn(),
+  remoteControlConnectedDevices: mocks.remoteControlConnectedDevices,
+}))
+
+import { DEFAULT_PREFERENCES } from '../../lib/types'
+import { useProjectsStore } from '../../stores/projectsStore'
+import { useUiStore } from '../../stores/uiStore'
+import { TitleBar } from './index'
+
+const claudeUsage = {
+  five_hour: { utilization: 10, resets_at: '2099-01-01T00:00:00Z' },
+  seven_day: { utilization: 20, resets_at: '2099-01-01T00:00:00Z' },
+  seven_day_opus: { utilization: 30, resets_at: '2099-01-01T00:00:00Z' },
+}
+const codexUsage = {
+  primary: { used_percent: 10, window_minutes: 300, resets_at_ms: 0 },
+  secondary: { used_percent: 20, window_minutes: 10_080, resets_at_ms: 0 },
+  plan: 'test',
+  rate_limited: false,
+  reset_credits: 0,
+}
+const antigravityUsage = {
+  status: 'ready' as const,
+  cli_path: 'agy',
+  used_percent: 10,
+  rate_limited: false,
+  buckets: [],
+}
+
+function setUsagePreferences(patch: Partial<typeof DEFAULT_PREFERENCES>) {
+  useProjectsStore.setState((state) => ({
+    preferences: { ...state.preferences, ...patch },
+  }))
+}
+
+describe('TitleBar provider usage polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    mocks.getCachedClaudeUsage.mockResolvedValue(claudeUsage)
+    mocks.getCachedCodexUsage.mockResolvedValue(codexUsage)
+    mocks.getCachedAntigravityUsage.mockResolvedValue(antigravityUsage)
+    setUsagePreferences({
+      topbarShowClaudeUsage: false,
+      topbarShowCodexUsage: false,
+      topbarShowAntigravityUsage: false,
+    })
+    useUiStore.setState({
+      claudeUsage,
+      codexUsage,
+      antigravityUsage,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    setUsagePreferences({
+      topbarShowClaudeUsage: DEFAULT_PREFERENCES.topbarShowClaudeUsage,
+      topbarShowCodexUsage: DEFAULT_PREFERENCES.topbarShowCodexUsage,
+      topbarShowAntigravityUsage: DEFAULT_PREFERENCES.topbarShowAntigravityUsage,
+    })
+  })
+
+  it('clears cached usage and never calls providers while all indicators are disabled', async () => {
+    const view = render(<TitleBar />)
+
+    expect(useUiStore.getState()).toMatchObject({
+      claudeUsage: null,
+      codexUsage: null,
+      antigravityUsage: null,
+    })
+
+    await act(() => vi.advanceTimersByTimeAsync(10 * 60_000))
+
+    expect(mocks.getCachedClaudeUsage).not.toHaveBeenCalled()
+    expect(mocks.getCachedCodexUsage).not.toHaveBeenCalled()
+    expect(mocks.getCachedAntigravityUsage).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('starts and cleans up each provider timer independently', async () => {
+    setUsagePreferences({
+      topbarShowClaudeUsage: true,
+      topbarShowCodexUsage: true,
+      topbarShowAntigravityUsage: false,
+    })
+    const view = render(<TitleBar />)
+
+    await act(() => vi.advanceTimersByTimeAsync(2_500))
+    expect(mocks.getCachedClaudeUsage).toHaveBeenCalledTimes(1)
+    expect(mocks.getCachedCodexUsage).toHaveBeenCalledTimes(1)
+    expect(mocks.getCachedAntigravityUsage).not.toHaveBeenCalled()
+
+    act(() => setUsagePreferences({ topbarShowClaudeUsage: false }))
+    expect(useUiStore.getState().claudeUsage).toBeNull()
+
+    await act(() => vi.advanceTimersByTimeAsync(5 * 60_000))
+    expect(mocks.getCachedClaudeUsage).toHaveBeenCalledTimes(1)
+    expect(mocks.getCachedCodexUsage).toHaveBeenCalledTimes(2)
+
+    act(() =>
+      setUsagePreferences({
+        topbarShowCodexUsage: false,
+        topbarShowAntigravityUsage: true,
+      }),
+    )
+    expect(useUiStore.getState().codexUsage).toBeNull()
+
+    await act(() => vi.advanceTimersByTimeAsync(3_000))
+    expect(mocks.getCachedAntigravityUsage).toHaveBeenCalledTimes(1)
+
+    await act(() => vi.advanceTimersByTimeAsync(5 * 60_000))
+    expect(mocks.getCachedClaudeUsage).toHaveBeenCalledTimes(1)
+    expect(mocks.getCachedCodexUsage).toHaveBeenCalledTimes(2)
+    expect(mocks.getCachedAntigravityUsage).toHaveBeenCalledTimes(2)
+    view.unmount()
+  })
+})

--- a/src/components/TitleBar/index.tsx
+++ b/src/components/TitleBar/index.tsx
@@ -178,6 +178,10 @@ export function TitleBar() {
 
                                                                             
   useEffect(() => {
+    if (!preferences.topbarShowClaudeUsage) {
+      setClaudeUsage(null)
+      return
+    }
     let cancelled = false
     let interval: number | null = null
     let consecutiveFailures = 0
@@ -208,11 +212,15 @@ export function TitleBar() {
       window.clearTimeout(startupDelay)
       if (interval !== null) window.clearInterval(interval)
     }
-  }, [setClaudeUsage])
+  }, [preferences.topbarShowClaudeUsage, setClaudeUsage])
 
                                                                                 
                                                                        
   useEffect(() => {
+    if (!preferences.topbarShowCodexUsage) {
+      setCodexUsage(null)
+      return
+    }
     let cancelled = false
     let interval: number | null = null
     let consecutiveFailures = 0
@@ -241,10 +249,14 @@ export function TitleBar() {
       window.clearTimeout(startupDelay)
       if (interval !== null) window.clearInterval(interval)
     }
-  }, [setCodexUsage])
+  }, [preferences.topbarShowCodexUsage, setCodexUsage])
 
                                                                                                      
   useEffect(() => {
+    if (!preferences.topbarShowAntigravityUsage) {
+      setAntigravityUsage(null)
+      return
+    }
     let cancelled = false
     let interval: number | null = null
     const tick = async () => {
@@ -269,7 +281,7 @@ export function TitleBar() {
       window.clearTimeout(startupDelay)
       if (interval !== null) window.clearInterval(interval)
     }
-  }, [setAntigravityUsage])
+  }, [preferences.topbarShowAntigravityUsage, setAntigravityUsage])
 
   const win = getCurrentWindow()
 

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -1156,7 +1156,8 @@ export const en = {
   'ui.titlebar.openMemoryAnalytics': 'Open memory analytics',
   'ui.titlebar.customize': 'Customize topbar',
   'ui.titlebar.customizeTitle': 'Customize topbar',
-  'ui.titlebar.customizeDescription': 'Choose which indicators appear in the topbar.',
+  'ui.titlebar.customizeDescription':
+    'Choose which indicators appear in the topbar. Enabling provider usage accesses existing provider or CLI credentials and may contact provider services.',
   'ui.titlebar.codexUsageTooltip': 'Codex: {primary}% in the current window · {secondary}% weekly',
   'ui.titlebar.antigravityUsageTooltip': 'Antigravity: {conversations} active conversations',
   'ui.titlebar.openUsageDetails': 'Open AI usage details',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -1170,7 +1170,8 @@ export const ptBR: Record<MessageKey, string> = {
   'ui.titlebar.openMemoryAnalytics': 'Abrir analytics de memória',
   'ui.titlebar.customize': 'Personalizar topbar',
   'ui.titlebar.customizeTitle': 'Personalizar topbar',
-  'ui.titlebar.customizeDescription': 'Escolha quais indicadores aparecem na topbar.',
+  'ui.titlebar.customizeDescription':
+    'Escolha quais indicadores aparecem na topbar. Ativar o uso de provedores acessa credenciais existentes do provedor ou CLI e pode contatar os serviços do provedor.',
   'ui.titlebar.codexUsageTooltip': 'Codex: {primary}% na janela atual · {secondary}% semanal',
   'ui.titlebar.antigravityUsageTooltip': 'Antigravity: {conversations} conversas ativas',
   'ui.titlebar.openUsageDetails': 'Abrir detalhes de uso de IA',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -523,7 +523,7 @@ export type ResourcePolicyPreferences = {
 }
 
 export type ProjectsFile = {
-  version: 7
+  version: 8
   groups: Group[]
                                                      
   ungroupedOrder: string[]
@@ -586,9 +586,9 @@ export const DEFAULT_PREFERENCES: Preferences = {
   spotifyClientId: '',
   spotifyClientSecret: '',
   discordRichPresenceEnabled: true,
-  topbarShowClaudeUsage: true,
-  topbarShowCodexUsage: true,
-  topbarShowAntigravityUsage: true,
+  topbarShowClaudeUsage: false,
+  topbarShowCodexUsage: false,
+  topbarShowAntigravityUsage: false,
   topbarShowSync: true,
   topbarShowProfile: true,
   topbarShowMemory: true,
@@ -629,7 +629,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
 }
 
 export const EMPTY_PROJECTS_FILE: ProjectsFile = {
-  version: 7,
+  version: 8,
   groups: [],
   ungroupedOrder: [],
   projects: [],

--- a/src/stores/projectsStore.migrations.test.ts
+++ b/src/stores/projectsStore.migrations.test.ts
@@ -39,6 +39,52 @@ describe('preference normalization', () => {
 })
 
 describe('projects file migration', () => {
+  it('defaults provider-backed usage polling to off for fresh data', () => {
+    expect(DEFAULT_PREFERENCES).toMatchObject({
+      topbarShowClaudeUsage: false,
+      topbarShowCodexUsage: false,
+      topbarShowAntigravityUsage: false,
+    })
+  })
+
+  it('turns legacy automatic provider polling off during the v8 migration', () => {
+    const migrated = migrate({
+      ...EMPTY_PROJECTS_FILE,
+      version: 7,
+      preferences: {
+        ...DEFAULT_PREFERENCES,
+        topbarShowClaudeUsage: true,
+        topbarShowCodexUsage: true,
+        topbarShowAntigravityUsage: true,
+      },
+    })
+
+    expect(migrated.preferences).toMatchObject({
+      topbarShowClaudeUsage: false,
+      topbarShowCodexUsage: false,
+      topbarShowAntigravityUsage: false,
+    })
+  })
+
+  it('preserves choices explicitly saved in v8 data', () => {
+    const migrated = migrate({
+      ...EMPTY_PROJECTS_FILE,
+      version: 8,
+      preferences: {
+        ...DEFAULT_PREFERENCES,
+        topbarShowClaudeUsage: true,
+        topbarShowCodexUsage: false,
+        topbarShowAntigravityUsage: true,
+      },
+    })
+
+    expect(migrated.preferences).toMatchObject({
+      topbarShowClaudeUsage: true,
+      topbarShowCodexUsage: false,
+      topbarShowAntigravityUsage: true,
+    })
+  })
+
   it('adds isolated layout histories when migrating v6 data', () => {
     const migrated = migrate({
       ...EMPTY_PROJECTS_FILE,
@@ -48,7 +94,7 @@ describe('projects file migration', () => {
       preferences: { ...DEFAULT_PREFERENCES, workspaceGridLayoutHistory: undefined },
     })
 
-    expect(migrated.version).toBe(7)
+    expect(migrated.version).toBe(8)
     expect(migrated.projects[0].gridLayoutHistory).toEqual([])
     expect(migrated.groups[0].gridLayoutHistory).toEqual([])
     expect(migrated.preferences.workspaceGridLayoutHistory).toEqual([])

--- a/src/stores/projectsStore.migrations.ts
+++ b/src/stores/projectsStore.migrations.ts
@@ -40,7 +40,9 @@ function normalizeStoredAccent(value: unknown, fallback?: string): string | unde
   return /^#(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i.test(value) ? value : fallback
 }
 
-function normalizeStoredAccents(file: ProjectsFile): ProjectsFile {
+type ProjectsFileV7 = Omit<ProjectsFile, 'version'> & { version: 7 }
+
+function normalizeStoredAccents<T extends ProjectsFile | ProjectsFileV7>(file: T): T {
   const normalizeTab = (tab: WorkspaceTab): WorkspaceTab => ({
     ...tab,
     color: normalizeStoredAccent(tab.color),
@@ -48,11 +50,11 @@ function normalizeStoredAccents(file: ProjectsFile): ProjectsFile {
 
   return {
     ...file,
-    groups: file.groups.map((group) => ({
+    groups: file.groups.map((group: Group) => ({
       ...group,
       color: normalizeStoredAccent(group.color, GROUP_COLORS[0])!,
     })),
-    projects: file.projects.map((project) => ({
+    projects: file.projects.map((project: Project) => ({
       ...project,
       color: normalizeStoredAccent(project.color),
     })),
@@ -61,7 +63,7 @@ function normalizeStoredAccents(file: ProjectsFile): ProjectsFile {
       tabs: file.workspace.tabs.map(normalizeTab),
       closedTabs: file.workspace.closedTabs?.map(normalizeTab),
     },
-  }
+  } as T
 }
 
 export function normalizePreferences(raw: LegacyPreferences | undefined): Preferences {
@@ -289,7 +291,7 @@ export function migrateWorkspaceNavigation(base: {
   }
 }
 
-function migrateToV7(parsed: any): ProjectsFile {
+function migrateToV7(parsed: any): ProjectsFileV7 {
   return normalizeStoredAccents({
     ...parsed,
     version: 7,
@@ -308,10 +310,27 @@ function migrateToV7(parsed: any): ProjectsFile {
   })
 }
 
+function migrateToV8(parsed: any, resetLegacyProviderUsage: boolean): ProjectsFile {
+  const preferences = normalizePreferences(parsed.preferences)
+  return {
+    ...parsed,
+    version: 8,
+    preferences: resetLegacyProviderUsage
+      ? {
+          ...preferences,
+          topbarShowClaudeUsage: false,
+          topbarShowCodexUsage: false,
+          topbarShowAntigravityUsage: false,
+        }
+      : preferences,
+  }
+}
+
 /** Migrates older files and normalizes restorable snapshots. */
 export function migrate(parsed: any): ProjectsFile {
-  if (parsed.version === 7) return migrateToV7(parsed)
-  if (parsed.version === 6) return migrateToV7(parsed)
+  if (parsed.version === 8) return migrateToV8(parsed, false)
+  if (parsed.version === 7) return migrateToV8(migrateToV7(parsed), true)
+  if (parsed.version === 6) return migrateToV8(migrateToV7(parsed), true)
 
   const v5Result = parsed.version === 5 ? parsed : migrateToV5(parsed)
 
@@ -321,12 +340,15 @@ export function migrate(parsed: any): ProjectsFile {
     orphanWorktrees: p.orphanWorktrees ?? [],
   }))
 
-  return migrateToV7({
-    ...v5Result,
-    version: 6,
-    projects: v6Projects,
-    preferences: normalizePreferences(v5Result.preferences),
-  })
+  return migrateToV8(
+    migrateToV7({
+      ...v5Result,
+      version: 6,
+      projects: v6Projects,
+      preferences: normalizePreferences(v5Result.preferences),
+    }),
+    true,
+  )
 }
 
 function migrateToV5(parsed: any): any {

--- a/src/stores/projectsStore.ts
+++ b/src/stores/projectsStore.ts
@@ -356,7 +356,7 @@ function nextWriteSequence(): number {
 
 function projectsPayload(state: ProjectsState): ProjectsFile {
   return {
-    version: 7,
+    version: 8,
     groups: state.groups,
     ungroupedOrder: state.ungroupedOrder,
     projects: state.projects,


### PR DESCRIPTION
Closes #120

## What changed

Makes Claude Code, Codex, and Antigravity usage polling opt-in:

- fresh profile defaults are off for all three provider-backed indicators;
- the projects schema advances to v8;
- v7 and older profiles have legacy automatic polling reset to off because those values predate explicit network/credential consent;
- choices explicitly saved in v8 are preserved;
- disabled indicators schedule no startup timeout or interval;
- toggling an indicator off cancels its timer and clears cached usage from the UI;
- each provider remains independently controllable through the existing topbar settings;
- English and PT-BR copy discloses that enabling usage may access existing provider/CLI credentials and contact provider services.

Discord Rich Presence is intentionally excluded and remains covered separately by #119.

## Verification

Tested on Garuda Linux:

- focused polling and migration suite — 2 files, 8 tests passed
- full frontend suite — 43 files, 287 tests passed
- `npm run build` — passed
- focused Prettier checks for the new/regression tests and changelog — passed
- targeted ESLint — zero errors; existing warnings remain in large legacy files
- `git diff --check` — passed

Regression evidence:

- before runtime gating and migration completion, the new suite failed three assertions: disabled providers retained cached values, timers continued polling after opt-out, and the old schema-version expectation failed;
- after the fix, all focused and full tests pass.

## Compatibility

Users can restore any individual indicator from Customize topbar. Once written as v8, that explicit choice is preserved on subsequent loads.
