### PR TITLE
fix(security): guard experimental agent execution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Changed
+
+- Experimental Agent Sandbox and Agent Canvas sessions now start with guarded Claude permissions and
+  Codex approval-on-request/workspace-write policies; unattended approval requests are denied and
+  surfaced in the worker status instead of being accepted automatically.
+
 ## [1.6.0] — 2026-08-17
 
 ### Added

--- a/src/lib/agentCanvasUtils.test.ts
+++ b/src/lib/agentCanvasUtils.test.ts
@@ -112,12 +112,16 @@ describe('tailSummary', () => {
 
 describe('execArgsFor', () => {
   it('returns documented argv per agent', () => {
-    expect(execArgsFor('codex', 'do it')).toEqual(['exec', '--skip-git-repo-check', 'do it'])
-    expect(execArgsFor('claude', 'do it')).toEqual([
-      '-p',
+    expect(execArgsFor('codex', 'do it')).toEqual([
+      '--ask-for-approval',
+      'on-request',
+      '--sandbox',
+      'workspace-write',
+      'exec',
+      '--skip-git-repo-check',
       'do it',
-      '--dangerously-skip-permissions',
     ])
+    expect(execArgsFor('claude', 'do it')).toEqual(['-p', 'do it'])
     expect(execArgsFor('opencode', 'do it')).toEqual(['run', 'do it'])
   })
 

--- a/src/lib/agentCanvasUtils.ts
+++ b/src/lib/agentCanvasUtils.ts
@@ -13,6 +13,7 @@ import {
 import type { AgentNode } from '../stores/agentCanvasStore'
 import { AGENT_COLORS, FAMILY_RANK } from './agentCanvasConfig'
 import { costLevel, shortModel } from './costFormat'
+import { guardedExecArgsFor } from './experimentalAgentPolicy'
 import type { ModelRate, SessionCost } from './tauri'
 import type { AgentType } from './types'
 
@@ -102,19 +103,9 @@ export function tailSummary(raw: string, max = 320): string {
   return clean.length > max ? `…${clean.slice(-max)}` : clean
 }
 
-                                                                                     
+/** Build guarded one-shot arguments for a real canvas worker. */
 export function execArgsFor(agent: AgentType, task: string): string[] | undefined {
-  switch (agent) {
-    case 'codex':
-      return ['exec', '--skip-git-repo-check', task]
-    case 'claude':
-                                                                                 
-      return ['-p', task, '--dangerously-skip-permissions']
-    case 'opencode':
-      return ['run', task]
-    default:
-      return undefined
-  }
+  return guardedExecArgsFor(agent, task)
 }
 
                                                            

--- a/src/lib/experimentalAgentPolicy.test.ts
+++ b/src/lib/experimentalAgentPolicy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import agentCanvasUtilsSource from './agentCanvasUtils.ts?raw'
+import experimentalAgentPolicySource from './experimentalAgentPolicy.ts?raw'
+import agentSandboxStoreSource from '../stores/agentSandboxStore.ts?raw'
+import {
+  codexApprovalDenial,
+  codexThreadStartParams,
+  codexTurnStartParams,
+  guardedExecArgsFor,
+} from './experimentalAgentPolicy'
+
+describe('experimental agent guarded defaults', () => {
+  it('launches Claude without bypassing permission checks', () => {
+    const args = guardedExecArgsFor('claude', 'do it')
+
+    expect(args).toEqual(['-p', 'do it'])
+    expect(args?.join(' ')).not.toContain('--dangerously-skip-permissions')
+  })
+
+  it('launches Codex with explicit guarded CLI policy', () => {
+    const args = guardedExecArgsFor('codex', 'do it')
+
+    expect(args).toEqual([
+      '--ask-for-approval',
+      'on-request',
+      '--sandbox',
+      'workspace-write',
+      'exec',
+      '--skip-git-repo-check',
+      'do it',
+    ])
+    expect(args?.join(' ')).not.toContain('danger-full-access')
+  })
+
+  it('uses guarded app-server policy for threads and every turn', () => {
+    expect(codexThreadStartParams('C:/repo')).toEqual({
+      cwd: 'C:/repo',
+      approvalPolicy: 'on-request',
+      sandbox: 'workspace-write',
+    })
+    expect(codexTurnStartParams('thread-1', 'do it')).toEqual({
+      threadId: 'thread-1',
+      input: [{ type: 'text', text: 'do it' }],
+      approvalPolicy: 'on-request',
+    })
+  })
+
+  it('declines command and file approval requests instead of accepting them', () => {
+    expect(codexApprovalDenial('item/commandExecution/requestApproval')).toEqual({
+      response: { decision: 'decline' },
+      statusMessage: 'Command approval required; request denied and worker paused.',
+    })
+    expect(codexApprovalDenial('item/fileChange/requestApproval')).toEqual({
+      response: { decision: 'decline' },
+      statusMessage: 'File change approval required; request denied and worker paused.',
+    })
+    expect(codexApprovalDenial('turn/completed')).toBeNull()
+  })
+
+  it('keeps dangerous defaults and automatic acceptance out of both experimental modes', () => {
+    const sources = [agentSandboxStoreSource, agentCanvasUtilsSource, experimentalAgentPolicySource]
+
+    for (const source of sources) {
+      expect(source).not.toContain('--dangerously-skip-permissions')
+      expect(source).not.toMatch(/approvalPolicy\s*:\s*['"]never['"]/)
+      expect(source).not.toContain('danger-full-access')
+      expect(source).not.toMatch(/decision\s*:\s*['"]accept['"]/)
+    }
+  })
+})

--- a/src/lib/experimentalAgentPolicy.ts
+++ b/src/lib/experimentalAgentPolicy.ts
@@ -1,0 +1,65 @@
+import type { AgentType } from './types'
+
+export const CODEX_APPROVAL_POLICY = 'on-request' as const
+export const CODEX_SANDBOX = 'workspace-write' as const
+
+const CODEX_GUARDED_CLI_ARGS = [
+  '--ask-for-approval',
+  CODEX_APPROVAL_POLICY,
+  '--sandbox',
+  CODEX_SANDBOX,
+] as const
+
+export function guardedCodexCliArgs(): string[] {
+  return [...CODEX_GUARDED_CLI_ARGS]
+}
+
+export function guardedExecArgsFor(agent: AgentType, task: string): string[] | undefined {
+  switch (agent) {
+    case 'codex':
+      return [...guardedCodexCliArgs(), 'exec', '--skip-git-repo-check', task]
+    case 'claude':
+      return ['-p', task]
+    case 'opencode':
+      return ['run', task]
+    default:
+      return undefined
+  }
+}
+
+export function codexThreadStartParams(cwd: string) {
+  return {
+    cwd,
+    approvalPolicy: CODEX_APPROVAL_POLICY,
+    sandbox: CODEX_SANDBOX,
+  }
+}
+
+export function codexTurnStartParams(threadId: string, text: string) {
+  return {
+    threadId,
+    input: [{ type: 'text' as const, text }],
+    approvalPolicy: CODEX_APPROVAL_POLICY,
+  }
+}
+
+type ApprovalDenial = {
+  response: { decision: 'decline' }
+  statusMessage: string
+}
+
+export function codexApprovalDenial(method: string): ApprovalDenial | null {
+  if (method === 'item/commandExecution/requestApproval') {
+    return {
+      response: { decision: 'decline' },
+      statusMessage: 'Command approval required; request denied and worker paused.',
+    }
+  }
+  if (method === 'item/fileChange/requestApproval') {
+    return {
+      response: { decision: 'decline' },
+      statusMessage: 'File change approval required; request denied and worker paused.',
+    }
+  }
+  return null
+}

--- a/src/stores/agentSandboxStore.ts
+++ b/src/stores/agentSandboxStore.ts
@@ -2,6 +2,13 @@ import { create } from 'zustand'
 import { nanoid } from 'nanoid'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 
+import {
+  codexApprovalDenial,
+  codexThreadStartParams,
+  codexTurnStartParams,
+  guardedCodexCliArgs,
+  guardedExecArgsFor,
+} from '../lib/experimentalAgentPolicy'
 import { agentHooksEndpoint, agentHooksSettingsPath, agentHooksToken, codexAppServerSend, codexAppServerStart, codexAppServerStop, killPty, listenCodexAppServer, listenPtyData, listenPtyExit, spawnPty, writePty } from '../lib/tauri'
 
 export type SandboxNodeStatus = 'starting' | 'idle' | 'working' | 'done' | 'error'
@@ -78,7 +85,7 @@ type SpawnPayload = {
 }
 
 const DEMO_NODES: Omit<SandboxNode, 'ptyId' | 'status' | 'lastMessage'>[] = [
-  { id: 'lead', label: 'Planner Claude · Haiku · YOLO', role: 'planner', command: 'claude', extraArgs: ['--model', 'haiku', '--dangerously-skip-permissions', '--append-system-prompt', SPAWN_BRIDGE_PROMPT], x: 90, y: 24, width: 420, height: 300, color: 'var(--agent-claude)' },
+  { id: 'lead', label: 'Planner Claude · Haiku · guarded', role: 'planner', command: 'claude', extraArgs: ['--model', 'haiku', '--append-system-prompt', SPAWN_BRIDGE_PROMPT], x: 90, y: 24, width: 420, height: 300, color: 'var(--agent-claude)' },
 ]
 
 const exitCleanups = new Map<string, () => void>()
@@ -164,7 +171,7 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
         ? payload.agent === 'codex'
           ? undefined
           : payload.agent === 'claude'
-            ? ['--model', 'haiku', '--dangerously-skip-permissions', '-p', task]
+            ? ['--model', 'haiku', ...(guardedExecArgsFor('claude', task) ?? [])]
             : undefined
         : undefined
       const node: SandboxNode = {
@@ -215,7 +222,11 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
               cwd: payload.cwd || cwd,
               command: node.command === 'shell' ? undefined : node.command,
               extraArgs: [
-                ...(automatedTaskArgs ?? (payload.agent === 'claude' ? ['--model', 'haiku', '--dangerously-skip-permissions'] : [])),
+                ...(automatedTaskArgs ?? (payload.agent === 'claude'
+                  ? ['--model', 'haiku']
+                  : payload.agent === 'codex'
+                    ? guardedCodexCliArgs()
+                    : [])),
                 ...(payload.agent === 'claude' ? ['--settings', settingsPath] : []),
               ],
               env: { ALETHE_AGENT_HOOKS_ENDPOINT: endpoint, ALETHE_AGENT_HOOKS_TOKEN: token },
@@ -250,6 +261,7 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
             let nextRequestId = 10
             let activeTurnId: string | null = null
             let initialTurnRequested = false
+            let approvalBlocked = false
             const cleanup = await listenCodexAppServer(appServerId, (event) => {
               const method = typeof event.method === 'string' ? event.method : ''
               const params = event.params && typeof event.params === 'object' ? event.params as Record<string, unknown> : {}
@@ -263,6 +275,7 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
                 set((state) => ({ nodes: state.nodes.map((item) => item.id === node.id ? { ...item, status: 'working', lastMessage: delta || item.lastMessage, output: `${item.output ?? ''}${delta}`.slice(-16000) } : item) }))
               }
               if (method === 'turn/started') {
+                approvalBlocked = false
                 const turn = params.turn && typeof params.turn === 'object' ? params.turn as Record<string, unknown> : null
                 const startedTurnId = typeof turn?.id === 'string' ? turn.id : null
                 if (startedTurnId) {
@@ -285,11 +298,28 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
                 }
                 turnOutput = ''
                 activeTurnId = null
-                set((state) => ({ nodes: state.nodes.map((item) => item.id === node.id ? { ...item, status: 'idle', output: `${item.output ?? ''}\n\n[Alethe] Turn completed. Ready for another message.\n` } : item) }))
+                const completedStatus: SandboxNodeStatus = approvalBlocked ? 'error' : 'idle'
+                set((state: AgentSandboxState) => ({ nodes: state.nodes.map((item) => item.id === node.id ? {
+                  ...item,
+                  status: completedStatus,
+                  output: `${item.output ?? ''}\n\n[Alethe] ${approvalBlocked ? 'Turn paused after an approval request was denied.' : 'Turn completed. Ready for another message.'}\n`,
+                } : item) }))
               }
-              if (method === 'item/commandExecution/requestApproval' || method === 'item/fileChange/requestApproval') {
+              const approvalDenial = codexApprovalDenial(method)
+              if (approvalDenial) {
+                approvalBlocked = true
                 const requestId = event.id
-                if (requestId !== undefined) void codexAppServerSend(appServerId, { id: requestId, result: { decision: 'accept' } }).catch(() => {})
+                if (requestId !== undefined) {
+                  void codexAppServerSend(appServerId, { id: requestId, result: approvalDenial.response }).catch((error) => {
+                    console.error('[sandbox] failed to deny Codex approval request', error)
+                  })
+                }
+                set((state: AgentSandboxState) => ({ nodes: state.nodes.map((item) => item.id === node.id ? {
+                  ...item,
+                  status: 'error' as SandboxNodeStatus,
+                  lastMessage: approvalDenial.statusMessage,
+                  output: `${item.output ?? ''}\n\n[Alethe] ${approvalDenial.statusMessage}\n`,
+                } : item) }))
               }
               if (event.id === 2 && threadId && task && !initialTurnRequested) {
                 initialTurnRequested = true
@@ -297,7 +327,7 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
                 void codexAppServerSend(appServerId, {
                   id: requestId,
                   method: 'turn/start',
-                  params: { threadId, input: [{ type: 'text', text: task }], approvalPolicy: 'never' },
+                  params: codexTurnStartParams(threadId, task),
                 }).catch((error) => console.error('[sandbox] app-server turn failed', error))
               }
               if (event.type === 'transport_error' || event.type === 'transport_closed') {
@@ -309,7 +339,7 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
             await codexAppServerSend(appServerId, {
               id: 2,
               method: 'thread/start',
-              params: { cwd: payload.cwd || cwd, approvalPolicy: 'never', sandbox: 'danger-full-access' },
+              params: codexThreadStartParams(payload.cwd || cwd),
             })
           } else if (automatedTaskArgs && ptyId) {
             let outputUnlisten: UnlistenFn | null = null
@@ -457,7 +487,7 @@ export const useAgentSandboxStore = create<AgentSandboxState>((set, get) => ({
           await codexAppServerSend(target.appServerId, {
             id: Date.now(),
             method: 'turn/start',
-            params: { threadId: target.threadId, input: [{ type: 'text', text: `[Message from ${source?.label ?? from}] ${text.trim()}` }], approvalPolicy: 'never' },
+            params: codexTurnStartParams(target.threadId, `[Message from ${source?.label ?? from}] ${text.trim()}`),
           })
       } else if (target.ptyId) {
         await writePty(target.ptyId, agentInput(target.command, source?.label ?? from, text))


### PR DESCRIPTION
Closes #121.

## Summary

- remove Claude's implicit `--dangerously-skip-permissions` mode from Agent Sandbox and Agent Canvas
- start Codex workers with `on-request` approval and `workspace-write` sandbox defaults
- deny unattended Codex app-server command and file-change approval requests instead of accepting them automatically
- surface denied approvals as a visible paused/error worker state
- centralize the guarded experimental-agent policy in a pure helper shared by Sandbox and Canvas
- add regression tests that reject dangerous Claude flags, Codex `never` approval, full-access sandboxing, and automatic approval

## Behavior trade-off

Agent Sandbox and Agent Canvas are experimental. This intentionally prefers stopping a worker over silently escalating it. Interactive Codex terminals can still present normal approval prompts. Unattended app-server workers deny the request, expose the denial in worker output/status, and require a follow-up rather than granting command or file access automatically.

This PR does not add or persist an unrestricted mode.

## Verification

- `npm test` — 43 files, 287 tests passed
- `npm test -- src/lib/experimentalAgentPolicy.test.ts src/lib/agentCanvasUtils.test.ts` — 2 files, 21 tests passed
- `npm run build` — passed
- targeted ESLint for changed TypeScript — 0 errors, 2 existing-style import-order warnings
- focused Prettier check for the changelog and new policy/test files — passed
- `git diff --check` — passed
- Codex CLI 0.146.0 accepted the emitted global ordering: `codex --ask-for-approval on-request --sandbox workspace-write exec --help`
- generated Codex 0.146.0 app-server bindings confirmed `approvalPolicy: on-request`, thread sandbox `workspace-write`, and `decline` responses for command/file approval requests

Regression proof: temporarily changing the centralized Codex approval policy back to `never` caused 2 focused tests to fail; restoring `on-request` returned the suite to green.

## Risk and rollback

The main risk is reduced unattended worker completion when a task needs approval. That is deliberate: the previous behavior silently accepted privileged operations. Rollback is the single commit, though restoring automatic approval is not recommended.

## Exclusions

- no persisted or per-session unrestricted mode
- no general Agent Hooks redesign
- no non-experimental terminal behavior changes
- no repository-wide formatting cleanup
