### PR TITLE
fix(linux): use host Wayland client in AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,24 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Prepare compatible Linux AppImage GTK plugin
+        if: matrix.platform == 'ubuntu-22.04'
+        env:
+          GTK_PLUGIN_COMMIT: b5eb8d05b4c0ed40107fe2158c5d8527f94568ef
+          GTK_PLUGIN_SHA256: cb379f9b0733e9ad9f8bd78f8c2fa038aef2478523bb7d4c8e64ff6a1ea3501a
+        run: |
+          set -euo pipefail
+          cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+          upstream_plugin="$cache_dir/alethe-gtk-upstream.sh"
+          mkdir -p "$cache_dir"
+          curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            "https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/$GTK_PLUGIN_COMMIT/linuxdeploy-plugin-gtk.sh" \
+            --output "$upstream_plugin"
+          printf '%s  %s\n' "$GTK_PLUGIN_SHA256" "$upstream_plugin" | sha256sum --check
+          chmod 0755 "$upstream_plugin"
+          install -m 0755 scripts/linuxdeploy-plugin-gtk-wrapper.sh \
+            "$cache_dir/linuxdeploy-plugin-gtk.sh"
+
       - name: Build and upload Tauri bundles
         uses: tauri-apps/tauri-action@v0
         env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Fixed
+
+- Linux AppImages now use the host Wayland client library, preventing blank windows on newer
+  Wayland/Mesa systems.
+
 ## [1.6.0] — 2026-08-17
 
 ### Added

--- a/scripts/linuxdeploy-plugin-gtk-wrapper.sh
+++ b/scripts/linuxdeploy-plugin-gtk-wrapper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# Deliberately avoid the `linuxdeploy-plugin-*` prefix: linuxdeploy scans the
+# cache for that pattern and would otherwise register this helper instead of
+# the repository-owned wrapper.
+upstream_plugin="$script_dir/alethe-gtk-upstream.sh"
+appdir=''
+
+if (($# == 1)) && [[ "$1" == '--plugin-api-version' ]]; then
+  exec "$upstream_plugin" "$@"
+fi
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --appdir)
+      if ((i + 1 < ${#args[@]})); then
+        appdir=${args[$((i + 1))]}
+      fi
+      ;;
+    --appdir=*)
+      appdir=${args[$i]#--appdir=}
+      ;;
+  esac
+done
+
+if [[ -z "$appdir" ]]; then
+  printf 'Alethe AppImage wrapper: missing --appdir argument\n' >&2
+  exit 2
+fi
+
+"$upstream_plugin" "$@"
+
+# Keep the Wayland client aligned with the host Mesa/EGL stack. The GTK plugin
+# runs before the AppImage output plugin, so removing it here keeps it out of
+# the final artifact while retaining the remaining GTK/WebKit dependencies.
+rm -f -- "$appdir"/usr/lib/libwayland-client.so*
+if compgen -G "$appdir/usr/lib/libwayland-client.so*" >/dev/null; then
+  printf 'Alethe AppImage wrapper: failed to remove bundled Wayland client\n' >&2
+  exit 1
+fi

--- a/src/lib/appImagePackaging.test.ts
+++ b/src/lib/appImagePackaging.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from 'node:child_process'
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '../..')
+const workflowPath = join(root, '.github/workflows/release.yml')
+const wrapperPath = join(root, 'scripts/linuxdeploy-plugin-gtk-wrapper.sh')
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true })
+  }
+})
+
+describe('Linux AppImage packaging', () => {
+  it('pins and verifies the wrapped GTK plugin only on Linux', () => {
+    const workflow = readFileSync(workflowPath, 'utf8')
+    const preparation = workflow.indexOf('Prepare compatible Linux AppImage GTK plugin')
+    const packaging = workflow.indexOf('uses: tauri-apps/tauri-action@v0')
+
+    expect(preparation).toBeGreaterThan(-1)
+    expect(preparation).toBeLessThan(packaging)
+    expect(workflow).toContain("if: matrix.platform == 'ubuntu-22.04'")
+    expect(workflow).toMatch(/GTK_PLUGIN_COMMIT: [0-9a-f]{40}/)
+    expect(workflow).toMatch(/GTK_PLUGIN_SHA256: [0-9a-f]{64}/)
+    expect(workflow).toContain('sha256sum --check')
+    expect(workflow).not.toContain('LD_PRELOAD')
+    expect(workflow).not.toContain('LINUXDEPLOY_EXCLUDED_LIBRARIES')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'runs the upstream GTK plugin before removing only the Wayland client',
+    () => {
+      const directory = mkdtempSync(join(tmpdir(), 'alethe-appimage-wrapper-'))
+      temporaryDirectories.push(directory)
+      const pluginDirectory = join(directory, 'plugin')
+      const appDirectory = join(directory, 'AppDir')
+      const libraryDirectory = join(appDirectory, 'usr/lib')
+      mkdirSync(pluginDirectory, { recursive: true })
+      mkdirSync(libraryDirectory, { recursive: true })
+      cpSync(wrapperPath, join(pluginDirectory, 'linuxdeploy-plugin-gtk.sh'))
+      writeFileSync(
+        join(pluginDirectory, 'alethe-gtk-upstream.sh'),
+        `#!/usr/bin/env bash\nset -euo pipefail\nif [[ "\${1:-}" == '--plugin-api-version' ]]; then printf '0\\n'; exit 0; fi\nappdir=''\nwhile (($#)); do\n  case "$1" in\n    --appdir) appdir=$2; shift 2 ;;\n    --appdir=*) appdir=\${1#--appdir=}; shift ;;\n    *) shift ;;\n  esac\ndone\ntouch "$appdir/usr/lib/libwayland-client.so.0"\ntouch "$appdir/usr/lib/libgtk-3.so.0"\n`,
+        { mode: 0o755 },
+      )
+
+      expect(
+        execFileSync('bash', [
+          join(pluginDirectory, 'linuxdeploy-plugin-gtk.sh'),
+          '--plugin-api-version',
+        ]).toString(),
+      ).toBe('0\n')
+
+      execFileSync('bash', [
+        join(pluginDirectory, 'linuxdeploy-plugin-gtk.sh'),
+        '--appdir',
+        appDirectory,
+      ])
+
+      expect(() => readFileSync(join(libraryDirectory, 'libwayland-client.so.0'))).toThrow()
+      expect(readFileSync(join(libraryDirectory, 'libgtk-3.so.0'))).toHaveLength(0)
+    },
+  )
+})


### PR DESCRIPTION
## Problem

The official v1.6.0 AppImage bundles Ubuntu-era `libwayland-client.so.0`. On Garuda Linux with KDE Plasma/Wayland and current Mesa, the packaged window is blank and WebKitGTK reports `EGL_BAD_PARAMETER`. Using the host Wayland client fixes rendering, but a hard-coded `LD_PRELOAD` path is not portable.

This addresses the packaged Wayland failure documented in #51.

## Approach

- Pin the upstream Tauri GTK linuxdeploy plugin to commit `b5eb8d05b4c0ed40107fe2158c5d8527f94568ef`.
- Verify its SHA-256 before execution.
- Install a repository-owned GTK plugin wrapper only for the Ubuntu 22.04 release matrix entry.
- Let the upstream plugin deploy GTK/WebKit dependencies normally.
- Remove only `usr/lib/libwayland-client.so*` before the AppImage output plugin runs, then fail if it remains.
- Keep the helper filename outside linuxdeploy's `linuxdeploy-plugin-*` discovery pattern and forward the required `--plugin-api-version` probe.

No `LD_PRELOAD` or host-specific library path is introduced. Windows and macOS release paths are unchanged.

## Verification

### Automated

- `npm test`: 43 files, 284 tests passed.
- `npm run build`: passed.
- Focused packaging test: 2 passed.
- Targeted ESLint: passed.
- Focused Prettier: passed.
- `bash -n scripts/linuxdeploy-plugin-gtk-wrapper.sh`: passed.
- `git diff --check`: passed.
- Sabotage proof: removing API-probe forwarding makes the focused regression test fail because linuxdeploy cannot register the wrapper.
- Earlier sabotage replacing client removal with server removal also made the focused regression test fail.

### Ubuntu 22.04 package

A clean Ubuntu 22.04-equivalent container build reached:

```text
Finished 1 bundle at:
  .../Alethe_1.6.0_amd64.AppImage
```

The command then stopped at updater signing because the local verification container intentionally has no release private key. Bundle creation had already completed; the release workflow supplies signing secrets.

Final AppImage:

- size: 87,235,064 bytes
- SHA-256: `2960fde57b25b1cd343cca8308eb7bec7d391a43e918c5bfd6420ea0500448c1`
- extracted `libwayland-client.so*`: zero
- retained Wayland cursor/EGL/server libraries
- retained WebKit injected bundle, desktop metadata, and icons

### KDE/Wayland smoke test

Launched the exact final artifact on Garuda Linux, KDE Plasma 6.7.2, Wayland, WebKitGTK 2.52.4, and Mesa 26.1.4 with:

- `LD_PRELOAD` explicitly absent
- `GDK_BACKEND=wayland`
- isolated config/data/cache directories

A direct capture of the AppImage process showed the complete Alethe shell and Quick Setup profile UI. The client area was not blank, black, white, transparent, or stuck loading.

## Risk and rollback

Risk is limited to Linux AppImage dependency resolution: the host must provide a compatible Wayland client, as supported Linux desktops already do. Other bundled GTK/WebKit and Wayland libraries remain unchanged.

Rollback is a revert of this commit, restoring Tauri's default GTK plugin download/bundling behavior.

## Exclusions

- no X11 behavior changes
- no Windows/macOS workflow changes
- no release-signing changes
- no general linuxdeploy replacement
- no `LD_PRELOAD` launcher
