### PR TITLE
fix(security): guard MCP registry activation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Changed
+
+- MCP registry package suggestions now require exact npm or PyPI versions, keep their published
+  provenance visible during review, and require an explicit third-party execution acknowledgement
+  before they can be added. Registry cache files are also restricted to the current user on Unix.
+
 ## [1.6.0] — 2026-08-17
 
 ### Added

--- a/src-tauri/src/mcp_catalog.rs
+++ b/src-tauri/src/mcp_catalog.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
-use std::fs;
-use std::path::PathBuf;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -90,10 +91,51 @@ fn cache_path(app: &tauri::AppHandle) -> Option<PathBuf> {
     )
 }
 
+#[cfg(unix)]
+fn make_cache_private(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn make_cache_private(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn read_cache_path(path: &Path) -> RegistryCache {
+    if path.exists() && make_cache_private(path).is_err() {
+        return RegistryCache::default();
+    }
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn write_cache_path(path: &Path, cache: &RegistryCache) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let raw = serde_json::to_string(cache).map_err(std::io::Error::other)?;
+    if path.exists() {
+        make_cache_private(path)?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    make_cache_private(path)?;
+    file.write_all(raw.as_bytes())
+}
+
 fn read_cache(app: &tauri::AppHandle) -> RegistryCache {
     cache_path(app)
-        .and_then(|path| fs::read_to_string(path).ok())
-        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .map(|path| read_cache_path(&path))
         .unwrap_or_default()
 }
 
@@ -101,14 +143,7 @@ fn write_cache(app: &tauri::AppHandle, cache: &RegistryCache) {
     let Some(path) = cache_path(app) else {
         return;
     };
-    if let Some(parent) = path.parent() {
-        if fs::create_dir_all(parent).is_err() {
-            return;
-        }
-    }
-    if let Ok(raw) = serde_json::to_string(cache) {
-        let _ = fs::write(path, raw);
-    }
+    let _ = write_cache_path(&path, cache);
 }
 
 fn text(value: &Value, key: &str) -> Option<String> {
@@ -192,31 +227,44 @@ fn argument_values(value: Option<&Value>) -> Vec<String> {
 }
 
 fn runtime_for(registry_type: &str, hint: Option<&str>) -> Option<&'static str> {
-    match hint {
-        Some("npx") => Some("npx"),
-        Some("uvx") => Some("uvx"),
-        Some("docker") => Some("docker"),
-        Some("dnx") => Some("dnx"),
-        _ => match registry_type {
-            "npm" => Some("npx"),
-            "pypi" => Some("uvx"),
-            "oci" => Some("docker"),
-            "nuget" => Some("dnx"),
-            _ => None,
-        },
+    match (registry_type, hint) {
+        ("npm", None | Some("npx")) => Some("npx"),
+        ("pypi", None | Some("uvx")) => Some("uvx"),
+        // OCI and NuGet metadata does not currently prove a complete immutable invocation.
+        _ => None,
     }
+}
+
+fn exact_package_version<'a>(registry_type: &str, raw: &'a str) -> Option<&'a str> {
+    let version = raw.trim();
+    let valid_characters = version.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '+' | '_' | '!')
+    });
+    let starts_with_digit = version
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_digit());
+    let ecosystem_valid = match registry_type {
+        "npm" => !version.contains(['_', '!']),
+        "pypi" => true,
+        _ => false,
+    };
+    (!version.is_empty() && starts_with_digit && valid_characters && ecosystem_valid)
+        .then_some(version)
 }
 
 fn package_install(package: &Value) -> Option<McpInstallOption> {
     let identifier = text(package, "identifier")?;
     let registry_type = text(package, "registryType").unwrap_or_default();
     let runtime = runtime_for(&registry_type, text(package, "runtimeHint").as_deref())?;
+    let raw_version = text(package, "version")?;
+    let version = exact_package_version(&registry_type, &raw_version)?;
 
     let mut args = argument_values(package.get("runtimeArguments"));
-    let version = text(package, "version");
-    args.push(match (&registry_type[..], version.as_deref()) {
-        ("npm", Some(version)) => format!("{identifier}@{version}"),
-        _ => identifier.clone(),
+    args.push(match registry_type.as_str() {
+        "npm" => format!("{identifier}@{version}"),
+        "pypi" => format!("{identifier}=={version}"),
+        _ => return None,
     });
     args.extend(argument_values(package.get("packageArguments")));
 
@@ -469,6 +517,72 @@ mod tests {
     }
 
     #[test]
+    fn a_pypi_package_uses_an_exact_uvx_requirement() {
+        let package: Value = serde_json::from_str(
+            r#"{
+              "registryType":"pypi",
+              "identifier":"example-mcp",
+              "version":"1.4.2",
+              "runtimeHint":"uvx",
+              "transport":{"type":"stdio"},
+              "packageArguments":[{"value":"--verbose"}]
+            }"#,
+        )
+        .expect("fixture");
+        let install = package_install(&package).expect("install");
+        assert_eq!(install.command.as_deref(), Some("uvx"));
+        assert_eq!(install.args, vec!["example-mcp==1.4.2", "--verbose"]);
+    }
+
+    #[test]
+    fn package_options_without_a_required_version_are_omitted() {
+        for registry_type in ["npm", "pypi"] {
+            let package = serde_json::json!({
+                "registryType": registry_type,
+                "identifier": "example-mcp",
+                "transport": { "type": "stdio" }
+            });
+            assert!(package_install(&package).is_none(), "{registry_type}");
+        }
+    }
+
+    #[test]
+    fn mutable_or_range_package_versions_are_omitted() {
+        for (registry_type, version) in [
+            ("npm", "latest"),
+            ("npm", "^1.2.3"),
+            ("npm", "1.2.*"),
+            ("pypi", ">=1.2"),
+            ("pypi", "1.2.*"),
+        ] {
+            let package = serde_json::json!({
+                "registryType": registry_type,
+                "identifier": "example-mcp",
+                "version": version,
+                "transport": { "type": "stdio" }
+            });
+            assert!(
+                package_install(&package).is_none(),
+                "{registry_type}:{version}"
+            );
+        }
+    }
+
+    #[test]
+    fn oci_and_nuget_package_options_are_not_exposed() {
+        for (registry_type, runtime_hint) in [("oci", "docker"), ("nuget", "dnx")] {
+            let package = serde_json::json!({
+                "registryType": registry_type,
+                "identifier": "example-mcp",
+                "version": "1.2.3",
+                "runtimeHint": runtime_hint,
+                "transport": { "type": "stdio" }
+            });
+            assert!(package_install(&package).is_none(), "{registry_type}");
+        }
+    }
+
+    #[test]
     fn environment_hints_carry_the_secret_flag() {
         let install = &parse(PACKAGE_SERVER).installs[0];
         let secret = install
@@ -530,5 +644,31 @@ mod tests {
         assert_eq!(page.entries.len(), 1);
         assert_eq!(page.next_cursor.as_deref(), Some("abc:1.0"));
         assert!(page.stale_since.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_files_are_created_and_tightened_to_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!(
+            "alethe-registry-cache-{}-{}",
+            std::process::id(),
+            crate::provider_common::now_ms()
+        ));
+        let path = dir.join("nested").join("registry-cache.json");
+        write_cache_path(&path, &RegistryCache::default()).expect("create cache");
+        assert_eq!(
+            fs::metadata(&path).expect("metadata").permissions().mode() & 0o777,
+            0o600
+        );
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("loosen fixture");
+        let _ = read_cache_path(&path);
+        assert_eq!(
+            fs::metadata(&path).expect("metadata").permissions().mode() & 0o777,
+            0o600
+        );
+        fs::remove_dir_all(dir).expect("clean fixture");
     }
 }

--- a/src/components/modals/mcp/AddServerFlow.module.css
+++ b/src/components/modals/mcp/AddServerFlow.module.css
@@ -114,7 +114,6 @@
   cursor: pointer;
 }
 
-
 .registry {
   display: flex;
   flex-direction: column;
@@ -204,6 +203,68 @@
 .registryInstall:hover {
   color: var(--accent);
   border-color: var(--accent);
+}
+
+.registryReview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-sunken);
+}
+
+.registryReview > span:first-child {
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
+.registryMetadata {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+}
+
+.registryMetadata > div {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 8px;
+  font-size: 11.5px;
+}
+
+.registryMetadata dt {
+  color: var(--fg-faint);
+}
+
+.registryMetadata dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--fg-muted);
+}
+
+.registryMetadata a {
+  color: var(--accent);
+}
+
+.registryAcknowledgement {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  line-height: 1.45;
+  cursor: pointer;
+}
+
+.registryAcknowledgement input {
+  flex: none;
+  margin-top: 2px;
 }
 
 .targetsBlock {

--- a/src/components/modals/mcp/AddServerFlow.tsx
+++ b/src/components/modals/mcp/AddServerFlow.tsx
@@ -1,16 +1,16 @@
 import { Plus, X } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useReducer, useState } from 'react'
 
 import { useT } from '../../../lib/i18n'
 import { mcpErrorKey, parsePastedServer, unsupportedFor } from '../../../lib/mcp'
 import {
-  mcpRegistrySearch,
-  mcpUpsert,
   type McpCatalogEntry,
   type McpEnvInput,
   type McpInstallOption,
   type McpRegistryPage,
+  mcpRegistrySearch,
   type McpServerInput,
+  mcpUpsert,
 } from '../../../lib/tauri'
 import type { McpAgent, McpCapability, McpScope } from '../../../lib/types'
 import { AGENT_TYPE_LABELS, MCP_AGENTS } from '../../../lib/types'
@@ -18,6 +18,7 @@ import { useUiStore } from '../../../stores/uiStore'
 import controls from '../controls.module.css'
 import { Modal } from '../Modal'
 import styles from './AddServerFlow.module.css'
+import { registryReviewAllowsSubmit, registryReviewReducer } from './registryReview'
 
 type Source = 'manual' | 'paste' | 'registry'
 type TransportKind = 'stdio' | 'http' | 'sse'
@@ -173,6 +174,7 @@ export function AddServerFlow({
   const [paste, setPaste] = useState('')
   const [targets, setTargets] = useState<McpAgent[]>(availableAgents)
   const [busy, setBusy] = useState(false)
+  const [registryReview, dispatchRegistryReview] = useReducer(registryReviewReducer, null)
 
   const manualServer: McpServerInput | null = useMemo(() => {
     const envInputs: McpEnvInput[] = rows
@@ -210,13 +212,7 @@ export function AddServerFlow({
 
   const pasted = source === 'paste' ? parsePastedServer(paste, name) : null
   const servers: McpServerInput[] =
-    source === 'paste'
-      ? pasted?.ok
-        ? pasted.servers
-        : []
-      : manualServer
-        ? [manualServer]
-        : []
+    source === 'paste' ? (pasted?.ok ? pasted.servers : []) : manualServer ? [manualServer] : []
 
   const blockedByAgent = useMemo(() => {
     const map = new Map<McpAgent, string[]>()
@@ -230,7 +226,11 @@ export function AddServerFlow({
   const selectable = targets.filter(
     (agent) => availableAgents.includes(agent) && !blockedByAgent.has(agent),
   )
-  const canSubmit = servers.length > 0 && selectable.length > 0 && !busy
+  const canSubmit =
+    servers.length > 0 &&
+    selectable.length > 0 &&
+    !busy &&
+    registryReviewAllowsSubmit(registryReview)
 
   const toggleTarget = (agent: McpAgent) =>
     setTargets((current) =>
@@ -256,7 +256,10 @@ export function AddServerFlow({
     setBusy(false)
     if (written.length > 0) {
       pushToast({
-        title: t('mcp.addWritten', { count: servers.length, agents: [...new Set(written)].join(', ') }),
+        title: t('mcp.addWritten', {
+          count: servers.length,
+          agents: [...new Set(written)].join(', '),
+        }),
         body: servers.map((server) => server.name).join(', '),
       })
     }
@@ -300,7 +303,10 @@ export function AddServerFlow({
             role="tab"
             aria-selected={source === option}
             className={`${controls.tabBtn} ${source === option ? controls.tabBtnActive : ''}`}
-            onClick={() => setSource(option)}
+            onClick={() => {
+              setSource(option)
+              dispatchRegistryReview({ type: 'reset' })
+            }}
           >
             {t(
               option === 'manual'
@@ -316,6 +322,7 @@ export function AddServerFlow({
       {source === 'registry' ? (
         <RegistryPicker
           onPick={(entry, install) => {
+            dispatchRegistryReview({ type: 'select', entry })
             setName(entry.suggestedName)
             if (install.kind === 'stdio') {
               setKind('stdio')
@@ -468,6 +475,53 @@ export function AddServerFlow({
                 </button>
               </div>
             </div>
+
+            {registryReview ? (
+              <div className={styles.registryReview}>
+                <span>{t('mcp.registryReviewTitle')}</span>
+                <dl className={styles.registryMetadata}>
+                  <div>
+                    <dt>{t('mcp.registryReviewOrigin')}</dt>
+                    <dd>{registryReview.origin}</dd>
+                  </div>
+                  <div>
+                    <dt>{t('mcp.registryReviewName')}</dt>
+                    <dd>{registryReview.title}</dd>
+                  </div>
+                  <div>
+                    <dt>{t('mcp.registryReviewVersion')}</dt>
+                    <dd>{registryReview.version}</dd>
+                  </div>
+                  {registryReview.repositoryUrl ? (
+                    <div>
+                      <dt>{t('mcp.registryReviewRepository')}</dt>
+                      <dd>
+                        <a
+                          href={registryReview.repositoryUrl}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                        >
+                          {registryReview.repositoryUrl}
+                        </a>
+                      </dd>
+                    </div>
+                  ) : null}
+                </dl>
+                <label className={styles.registryAcknowledgement}>
+                  <input
+                    type="checkbox"
+                    checked={registryReview.acknowledged}
+                    onChange={(event) =>
+                      dispatchRegistryReview({
+                        type: 'acknowledge',
+                        value: event.target.checked,
+                      })
+                    }
+                  />
+                  <span>{t('mcp.registryAcknowledgement')}</span>
+                </label>
+              </div>
+            ) : null}
           </>
         ) : (
           <label className={styles.field}>
@@ -477,7 +531,9 @@ export function AddServerFlow({
               className={styles.mono}
               value={paste}
               onChange={(event) => setPaste(event.target.value)}
-              placeholder={'{\n  "mcpServers": {\n    "playwright": {\n      "command": "npx",\n      "args": ["@playwright/mcp@latest"]\n    }\n  }\n}'}
+              placeholder={
+                '{\n  "mcpServers": {\n    "playwright": {\n      "command": "npx",\n      "args": ["@playwright/mcp@latest"]\n    }\n  }\n}'
+              }
             />
             <span className={styles.hint}>
               {paste.trim().length === 0

--- a/src/components/modals/mcp/registryReview.test.ts
+++ b/src/components/modals/mcp/registryReview.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import type { McpCatalogEntry } from '../../../lib/tauri'
+import { registryReviewAllowsSubmit, registryReviewReducer } from './registryReview'
+
+const ENTRY: McpCatalogEntry = {
+  id: 'io.example/server',
+  suggestedName: 'server',
+  title: 'Example server',
+  description: 'Example',
+  version: '1.2.3',
+  repositoryUrl: 'https://example.com/repository',
+  installs: [],
+}
+
+describe('registry review acknowledgement', () => {
+  it('blocks a newly selected registry config until explicitly acknowledged', () => {
+    const selected = registryReviewReducer(null, { type: 'select', entry: ENTRY })
+
+    expect(selected).toMatchObject({
+      origin: ENTRY.id,
+      title: ENTRY.title,
+      version: ENTRY.version,
+      repositoryUrl: ENTRY.repositoryUrl,
+      acknowledged: false,
+    })
+    expect(registryReviewAllowsSubmit(selected)).toBe(false)
+
+    const acknowledged = registryReviewReducer(selected, { type: 'acknowledge', value: true })
+    expect(registryReviewAllowsSubmit(acknowledged)).toBe(true)
+  })
+
+  it('resets acknowledgement for a new selection and removes gating when registry review is reset', () => {
+    const selected = registryReviewReducer(null, { type: 'select', entry: ENTRY })
+    const acknowledged = registryReviewReducer(selected, { type: 'acknowledge', value: true })
+    const replacement = registryReviewReducer(acknowledged, {
+      type: 'select',
+      entry: { ...ENTRY, id: 'io.example/other', title: 'Other server' },
+    })
+
+    expect(replacement?.acknowledged).toBe(false)
+    expect(registryReviewAllowsSubmit(replacement)).toBe(false)
+
+    const reset = registryReviewReducer(replacement, { type: 'reset' })
+    expect(reset).toBeNull()
+    expect(registryReviewAllowsSubmit(reset)).toBe(true)
+  })
+})

--- a/src/components/modals/mcp/registryReview.ts
+++ b/src/components/modals/mcp/registryReview.ts
@@ -1,0 +1,38 @@
+import type { McpCatalogEntry } from '../../../lib/tauri'
+
+export type RegistryReview = {
+  origin: string
+  title: string
+  version: string
+  repositoryUrl: string | null
+  acknowledged: boolean
+}
+
+export type RegistryReviewAction =
+  | { type: 'select'; entry: McpCatalogEntry }
+  | { type: 'acknowledge'; value: boolean }
+  | { type: 'reset' }
+
+export function registryReviewReducer(
+  state: RegistryReview | null,
+  action: RegistryReviewAction,
+): RegistryReview | null {
+  switch (action.type) {
+    case 'select':
+      return {
+        origin: action.entry.id,
+        title: action.entry.title,
+        version: action.entry.version,
+        repositoryUrl: action.entry.repositoryUrl,
+        acknowledged: false,
+      }
+    case 'acknowledge':
+      return state ? { ...state, acknowledged: action.value } : null
+    case 'reset':
+      return null
+  }
+}
+
+export function registryReviewAllowsSubmit(review: RegistryReview | null): boolean {
+  return review === null || review.acknowledged
+}

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -1956,6 +1956,13 @@ export const en = {
   'mcp.registryNoResults': 'No server matched.',
   'mcp.registryOffline': 'The registry could not be reached and nothing was cached for this search.',
   'mcp.registryStale': 'Registry unreachable — showing the copy saved on {date}.',
+  'mcp.registryReviewTitle': 'Registry selection',
+  'mcp.registryReviewOrigin': 'Registry origin',
+  'mcp.registryReviewName': 'Published title',
+  'mcp.registryReviewVersion': 'Published version',
+  'mcp.registryReviewRepository': 'Repository',
+  'mcp.registryAcknowledgement':
+    'I understand this is third-party software that may execute local code or contact remote services when an agent launches, and that a registry listing is not an endorsement by Alethe.',
   'mcp.addWritten': '{count} server(s) added to {agents}',
   'mcp.fieldName': 'Name',
   'mcp.fieldTransport': 'Transport',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -1972,6 +1972,13 @@ export const ptBR: Record<MessageKey, string> = {
   'mcp.registryNoResults': 'Nenhum servidor encontrado.',
   'mcp.registryOffline': 'Não deu para alcançar o registry e não há nada em cache para esta busca.',
   'mcp.registryStale': 'Registry fora do ar — mostrando a cópia salva em {date}.',
+  'mcp.registryReviewTitle': 'Seleção do registry',
+  'mcp.registryReviewOrigin': 'Origem no registry',
+  'mcp.registryReviewName': 'Título publicado',
+  'mcp.registryReviewVersion': 'Versão publicada',
+  'mcp.registryReviewRepository': 'Repositório',
+  'mcp.registryAcknowledgement':
+    'Entendo que este é um software de terceiros que pode executar código local ou acessar serviços remotos quando um agente iniciar, e que aparecer no registry não significa um endosso da Alethe.',
   'mcp.addWritten': '{count} servidor(es) adicionado(s) em {agents}',
   'mcp.fieldName': 'Nome',
   'mcp.fieldTransport': 'Transporte',


### PR DESCRIPTION
## Summary

- require exact npm and PyPI versions for registry-derived local package commands
- omit missing, mutable/range, OCI, and NuGet package options that cannot be mapped to a complete supported invocation
- require an explicit, non-prechecked third-party execution/network acknowledgement before saving a registry-derived configuration
- keep registry origin, published title/version, repository, and selected target agents visible during review
- create and migrate the registry cache to owner-only permissions on Unix

Closes #136.

## Security model

The official MCP registry is treated as a discovery source, not an Alethe trust endorsement. Selecting an entry can cause an agent to execute third-party local code or contact a remote service on a later launch, so activation now requires explicit acknowledgement.

Exact ecosystem versions reduce mutable-tag/range risk but are not a cryptographic integrity guarantee. This PR does not claim package authenticity or add malware scanning. Manual configuration remains available for unsupported OCI/NuGet cases.

## Verification

- Rust focused MCP catalog suite: 11 passed.
- Full Rust library suite: 231 passed, one existing ignored.
- Focused registry review suite: 2 passed.
- Full frontend suite: 43 files, 284 tests passed.
- Production frontend build passed.
- Targeted ESLint: zero errors; one existing hook dependency warning in `AddServerFlow.tsx`.
- Focused Prettier passed.
- Rustfmt on the touched Rust file passed.
- `git diff --check` passed.

Sabotage verification:

- removing the PyPI `==version` pin made the exact-uvx regression test fail;
- bypassing the acknowledgement gate made both review tests fail.

## Compatibility and rollback

- npm and PyPI entries with exact versions retain their normal `npx`/`uvx` behavior;
- remote HTTP/SSE options remain available but require the same registry acknowledgement;
- OCI/NuGet registry suggestions are omitted until Alethe can construct complete supported immutable invocations; users can still configure them manually;
- rollback is a revert of this commit, restoring prior registry mapping and submission behavior.

## Exclusions

- no executor redesign
- no package download/hash verification
- no pipe-to-shell installer changes (handled separately in #128)
- no changes to manually entered or pasted MCP configurations
