### PR TITLE
fix(security): fail closed remote control

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,13 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Changed
+
+- Remote Control now requires an explicit summary of its local-network exposure and configured access
+  policy before it is enabled. It stays off unless every policy update and both LAN listeners succeed,
+  persists failed-start rollback immediately, and serializes disable/session revocation against remote
+  terminal writes.
+
 ## [1.6.0] — 2026-08-17
 
 ### Added

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -92,11 +92,13 @@ struct AuthFailures {
 }
 
 pub struct RemoteHub {
+    lifecycle: Mutex<()>,
     pairing_token: Mutex<String>,
     pairing_until: Mutex<Option<Instant>>,
     host: Mutex<String>,
     running: AtomicBool,
     generation: AtomicU64,
+    latest_control_request_id: AtomicU64,
     http_port: AtomicU16,
     ws_port: AtomicU16,
     next_session_id: AtomicUsize,
@@ -113,17 +115,19 @@ pub struct RemoteHub {
 impl RemoteHub {
     fn new() -> Self {
         Self {
+            lifecycle: Mutex::new(()),
             pairing_token: Mutex::new(nanoid::nanoid!(32)),
             pairing_until: Mutex::new(None),
             host: Mutex::new(local_ip()),
             running: AtomicBool::new(false),
             generation: AtomicU64::new(0),
+            latest_control_request_id: AtomicU64::new(0),
             http_port: AtomicU16::new(0),
             ws_port: AtomicU16::new(0),
             next_session_id: AtomicUsize::new(1),
             max_devices: AtomicUsize::new(1),
             session_expiry_secs: AtomicU64::new(DEFAULT_SESSION_EXPIRY_SECS),
-            read_only: AtomicBool::new(false),
+            read_only: AtomicBool::new(true),
             allow_shell_input: AtomicBool::new(false),
             connections: AtomicUsize::new(0),
             sessions: Mutex::new(Vec::new()),
@@ -138,6 +142,15 @@ impl RemoteHub {
 
     fn is_active(&self, generation: u64) -> bool {
         self.running.load(Ordering::SeqCst) && self.generation.load(Ordering::SeqCst) == generation
+    }
+
+    fn record_control_request(&self, request_id: u64) {
+        self.latest_control_request_id
+            .fetch_max(request_id, Ordering::SeqCst);
+    }
+
+    fn control_request_is_current(&self, request_id: u64) -> bool {
+        self.latest_control_request_id.load(Ordering::SeqCst) == request_id
     }
 
     fn host(&self) -> String {
@@ -203,6 +216,7 @@ impl RemoteHub {
 
     fn info(&self) -> RemoteInfo {
         self.prune_expired();
+        let enabled = self.enabled();
         let http_port = self.http_port.load(Ordering::SeqCst);
         let ws_port = self.ws_port.load(Ordering::SeqCst);
         let host = self.host();
@@ -230,7 +244,7 @@ impl RemoteHub {
             })
             .unwrap_or_default();
         RemoteInfo {
-            enabled: self.enabled(),
+            enabled,
             connected_devices: devices.len(),
             online_devices: devices.iter().filter(|device| device.online).count(),
             max_devices: self.max_devices.load(Ordering::Relaxed),
@@ -242,8 +256,44 @@ impl RemoteHub {
             devices,
             pairing_url,
             qr_svg,
-            http_url: (http_port != 0).then(|| format!("http://{host}:{http_port}")),
-            ws_url: (ws_port != 0).then(|| format!("ws://{host}:{ws_port}")),
+            http_url: (enabled && http_port != 0).then(|| format!("http://{host}:{http_port}")),
+            ws_url: (enabled && ws_port != 0).then(|| format!("ws://{host}:{ws_port}")),
+        }
+    }
+
+    fn activate(&self, http_port: u16, ws_port: u16) -> u64 {
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        self.http_port.store(http_port, Ordering::SeqCst);
+        self.ws_port.store(ws_port, Ordering::SeqCst);
+        self.running.store(true, Ordering::SeqCst);
+        generation
+    }
+
+    fn shutdown(&self) {
+        self.running.store(false, Ordering::SeqCst);
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        self.http_port.store(0, Ordering::SeqCst);
+        self.ws_port.store(0, Ordering::SeqCst);
+        self.revoke_all();
+        self.close_pairing_window();
+    }
+
+    fn fail_generation(&self, generation: u64) {
+        if self
+            .generation
+            .compare_exchange(
+                generation,
+                generation + 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            self.running.store(false, Ordering::SeqCst);
+            self.http_port.store(0, Ordering::SeqCst);
+            self.ws_port.store(0, Ordering::SeqCst);
+            self.revoke_all();
+            self.close_pairing_window();
         }
     }
 
@@ -492,31 +542,57 @@ pub fn hub() -> Arc<RemoteHub> {
     HUB.get_or_init(|| Arc::new(RemoteHub::new())).clone()
 }
 
-pub fn start(app: AppHandle, sessions: PtySessions) {
+pub fn start(app: AppHandle, sessions: PtySessions, request_id: u64) -> Result<(), String> {
     let hub = hub();
-    if hub.running.swap(true, Ordering::SeqCst) {
-        return;
+    let _lifecycle = hub
+        .lifecycle
+        .lock()
+        .map_err(|_| "Remote control cannot start because its lifecycle lock is unavailable. Restart Alethe and try again.".to_string())?;
+    if !hub.control_request_is_current(request_id) || hub.enabled() {
+        return Ok(());
     }
     hub.refresh_host();
-    let generation = hub.generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let host = hub.host();
+    let listeners = bind_remote_listeners(&host, bind_listener)?;
+    if !hub.control_request_is_current(request_id) {
+        return Ok(());
+    }
+    let http_port = listeners
+        .http
+        .local_addr()
+        .map_err(|_| {
+            "Remote control could not inspect its HTTP listener. Restart Alethe and try again."
+                .to_string()
+        })?
+        .port();
+    let ws_port = listeners
+        .websocket
+        .local_addr()
+        .map_err(|_| {
+            "Remote control could not inspect its WebSocket listener. Restart Alethe and try again."
+                .to_string()
+        })?
+        .port();
+    let generation = hub.activate(http_port, ws_port);
+    let BoundListeners { http, websocket } = listeners;
     let http_hub = Arc::clone(&hub);
     let http_sessions = Arc::clone(&sessions);
     let http_app = app.clone();
-    thread::spawn(move || run_http(http_app, http_hub, http_sessions, generation));
+    thread::spawn(move || run_http(http, http_app, http_hub, http_sessions, generation));
 
     let ws_hub = Arc::clone(&hub);
     let ws_sessions = Arc::clone(&sessions);
-    thread::spawn(move || run_websocket(ws_hub, ws_sessions, generation));
+    thread::spawn(move || run_websocket(websocket, ws_hub, ws_sessions, generation));
+    eprintln!("[remote] LAN client available at http://{host}:{http_port}");
+    Ok(())
 }
 
-pub fn stop() {
-    let hub = hub();
-    hub.running.store(false, Ordering::SeqCst);
-    hub.generation.fetch_add(1, Ordering::SeqCst);
-    hub.http_port.store(0, Ordering::SeqCst);
-    hub.ws_port.store(0, Ordering::SeqCst);
-    hub.revoke_all();
-    hub.close_pairing_window();
+fn stop(hub: &Arc<RemoteHub>, request_id: u64) {
+    let _lifecycle = hub.lifecycle.lock().ok();
+    if !hub.control_request_is_current(request_id) {
+        return;
+    }
+    hub.shutdown();
     eprintln!("[remote] LAN remote control disabled");
 }
 
@@ -600,14 +676,16 @@ pub fn remote_control_set_enabled(
     app: AppHandle,
     sessions: tauri::State<'_, PtySessions>,
     enabled: bool,
-) -> RemoteInfo {
+    request_id: u64,
+) -> Result<RemoteInfo, String> {
     let remote = hub();
+    remote.record_control_request(request_id);
     if enabled {
-        start(app, Arc::clone(sessions.inner()));
+        start(app, Arc::clone(sessions.inner()), request_id)?;
     } else {
-        stop();
+        stop(&remote, request_id);
     }
-    remote.info()
+    Ok(remote.info())
 }
 
 struct ConnectionGuard(Arc<RemoteHub>);
@@ -629,17 +707,13 @@ impl Drop for ConnectionGuard {
     }
 }
 
-fn run_http(app: AppHandle, hub: Arc<RemoteHub>, sessions: PtySessions, generation: u64) {
-    let host = hub.host();
-    let Some(listener) = bind_listener(&host, HTTP_START, HTTP_END) else {
-        eprintln!("[remote] unable to bind LAN HTTP listener");
-        stop();
-        return;
-    };
-    let port = listener.local_addr().map(|addr| addr.port()).unwrap_or(0);
-    hub.http_port.store(port, Ordering::SeqCst);
-    eprintln!("[remote] LAN client available at http://{host}:{port}");
-    let _ = listener.set_nonblocking(true);
+fn run_http(
+    listener: TcpListener,
+    app: AppHandle,
+    hub: Arc<RemoteHub>,
+    sessions: PtySessions,
+    generation: u64,
+) {
     while hub.is_active(generation) {
         let stream = match listener.accept() {
             Ok((stream, _)) => stream,
@@ -661,7 +735,7 @@ fn run_http(app: AppHandle, hub: Arc<RemoteHub>, sessions: PtySessions, generati
         let app = app.clone();
         thread::spawn(move || {
             let _guard = guard;
-            if let Err(error) = handle_http(&mut stream, &app, &hub, &sessions) {
+            if let Err(error) = handle_http(&mut stream, &app, &hub, &sessions, generation) {
                 eprintln!("[remote] HTTP request failed: {error}");
                 let _ = respond(
                     &mut stream,
@@ -672,21 +746,15 @@ fn run_http(app: AppHandle, hub: Arc<RemoteHub>, sessions: PtySessions, generati
             }
         });
     }
-    if hub.generation.load(Ordering::SeqCst) == generation {
-        hub.http_port.store(0, Ordering::SeqCst);
-    }
+    hub.fail_generation(generation);
 }
 
-fn run_websocket(hub: Arc<RemoteHub>, sessions: PtySessions, generation: u64) {
-    let host = hub.host();
-    let Some(listener) = bind_listener(&host, HTTP_START + 1, HTTP_END + 1) else {
-        eprintln!("[remote] unable to bind LAN WebSocket listener");
-        stop();
-        return;
-    };
-    let port = listener.local_addr().map(|addr| addr.port()).unwrap_or(0);
-    hub.ws_port.store(port, Ordering::SeqCst);
-    let _ = listener.set_nonblocking(true);
+fn run_websocket(
+    listener: TcpListener,
+    hub: Arc<RemoteHub>,
+    sessions: PtySessions,
+    generation: u64,
+) {
     while hub.is_active(generation) {
         let stream = match listener.accept() {
             Ok((stream, _)) => stream,
@@ -710,9 +778,7 @@ fn run_websocket(hub: Arc<RemoteHub>, sessions: PtySessions, generation: u64) {
             handle_websocket(stream, hub, sessions, generation, address);
         });
     }
-    if hub.generation.load(Ordering::SeqCst) == generation {
-        hub.ws_port.store(0, Ordering::SeqCst);
-    }
+    hub.fail_generation(generation);
 }
 
 fn allowed_origin(hub: &RemoteHub) -> String {
@@ -911,6 +977,7 @@ fn handle_http(
     app: &AppHandle,
     hub: &Arc<RemoteHub>,
     sessions: &PtySessions,
+    generation: u64,
 ) -> Result<(), String> {
     let address = stream
         .peer_addr()
@@ -922,6 +989,14 @@ fn handle_http(
             429,
             "application/json",
             r#"{"error":"Too many failed attempts"}"#,
+        );
+    }
+    if !hub.is_active(generation) {
+        return respond(
+            stream,
+            403,
+            "application/json",
+            r#"{"error":"Remote control is disabled"}"#,
         );
     }
     let (head, body) = read_request(stream)?;
@@ -983,7 +1058,7 @@ fn handle_http(
         };
         hub.clear_auth_failures(&address);
         return handle_api(
-            stream, app, hub, sessions, session_id, method, target, &body,
+            stream, app, hub, sessions, generation, session_id, method, target, &body,
         );
     }
 
@@ -1021,6 +1096,7 @@ fn handle_api(
     app: &AppHandle,
     hub: &Arc<RemoteHub>,
     sessions: &PtySessions,
+    generation: u64,
     session_id: usize,
     method: &str,
     target: &str,
@@ -1106,7 +1182,17 @@ fn handle_api(
                 r#"{"error":"Sending commands to shell terminals is disabled"}"#,
             );
         }
-        write_remote(sessions, &payload.pty_id, &format!("{text}\r"))?;
+        let write_completed = with_active_remote_session(hub, generation, session_id, || {
+            write_remote(sessions, &payload.pty_id, &format!("{text}\r"))
+        })?;
+        if !write_completed {
+            return respond(
+                stream,
+                401,
+                "application/json",
+                r#"{"error":"Remote session is no longer active"}"#,
+            );
+        }
         let device_name = hub.device_name(session_id);
         eprintln!(
             "[remote] {device_name} (device {session_id}) sent {} chars to {}",
@@ -1304,6 +1390,26 @@ fn write_remote(sessions: &PtySessions, id: &str, data: &str) -> Result<(), Stri
     writer.flush().map_err(|e| e.to_string())
 }
 
+fn with_active_remote_session<F>(
+    hub: &RemoteHub,
+    generation: u64,
+    session_id: usize,
+    write: F,
+) -> Result<bool, String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    let _lifecycle = hub
+        .lifecycle
+        .lock()
+        .map_err(|_| "Remote control lifecycle lock is unavailable".to_string())?;
+    if !hub.is_active(generation) || !hub.session_alive(session_id) {
+        return Ok(false);
+    }
+    write()?;
+    Ok(true)
+}
+
 fn respond(
     stream: &mut TcpStream,
     status: u16,
@@ -1327,6 +1433,38 @@ fn respond(
     stream
         .write_all(response.as_bytes())
         .map_err(|e| e.to_string())
+}
+
+struct BoundListeners {
+    http: TcpListener,
+    websocket: TcpListener,
+}
+
+fn bind_remote_listeners<F>(host: &str, mut bind: F) -> Result<BoundListeners, String>
+where
+    F: FnMut(&str, u16, u16) -> Option<TcpListener>,
+{
+    let http = bind(host, HTTP_START, HTTP_END).ok_or_else(|| {
+        format!(
+            "Remote control could not open an HTTP listener on local address {host} (ports {HTTP_START}-{HTTP_END}). Close another app using that range or change networks, then try again."
+        )
+    })?;
+    let websocket = bind(host, HTTP_START + 1, HTTP_END + 1).ok_or_else(|| {
+        format!(
+            "Remote control could not open a WebSocket listener on local address {host} (ports {}-{}). Close another app using that range or change networks, then try again.",
+            HTTP_START + 1,
+            HTTP_END + 1
+        )
+    })?;
+    http.set_nonblocking(true).map_err(|_| {
+        "Remote control could not configure its HTTP listener. Restart Alethe and try again."
+            .to_string()
+    })?;
+    websocket.set_nonblocking(true).map_err(|_| {
+        "Remote control could not configure its WebSocket listener. Restart Alethe and try again."
+            .to_string()
+    })?;
+    Ok(BoundListeners { http, websocket })
 }
 
 fn bind_listener(host: &str, start: u16, end: u16) -> Option<TcpListener> {
@@ -1423,8 +1561,155 @@ fn local_ip() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{find_headers_end, header_value, percent_decode, RemoteHub};
+    use super::{
+        bind_remote_listeners, find_headers_end, header_value, percent_decode,
+        with_active_remote_session, RemoteHub,
+    };
     use std::cell::Cell;
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{mpsc, Arc};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn listener_startup_rolls_back_when_the_second_bind_fails() {
+        let hub = RemoteHub::new();
+        let calls = Cell::new(0);
+        let first_address = Cell::new(None);
+
+        let result = bind_remote_listeners("127.0.0.1", |_, _, _| {
+            calls.set(calls.get() + 1);
+            if calls.get() == 1 {
+                let listener = TcpListener::bind(("127.0.0.1", 0)).expect("first listener");
+                first_address.set(Some(listener.local_addr().expect("listener address")));
+                Some(listener)
+            } else {
+                None
+            }
+        });
+
+        let error = result.err().expect("WebSocket bind should fail");
+        assert!(error.contains("WebSocket listener"));
+        assert!(error.contains("try again"));
+        assert!(!hub.enabled());
+        assert_eq!(hub.http_port.load(Ordering::SeqCst), 0);
+        assert_eq!(hub.ws_port.load(Ordering::SeqCst), 0);
+        TcpListener::bind(
+            first_address
+                .get()
+                .expect("first address should be captured"),
+        )
+        .expect("the successful first listener must be dropped on rollback");
+    }
+
+    #[test]
+    fn activation_reports_enabled_only_with_both_ports() {
+        let hub = RemoteHub::new();
+
+        let generation = hub.activate(9340, 9341);
+        let info = hub.info();
+
+        assert!(info.enabled);
+        assert_eq!(generation, hub.generation.load(Ordering::SeqCst));
+        assert!(info
+            .http_url
+            .as_deref()
+            .is_some_and(|url| url.ends_with(":9340")));
+        assert!(info
+            .ws_url
+            .as_deref()
+            .is_some_and(|url| url.ends_with(":9341")));
+    }
+
+    #[test]
+    fn backend_defaults_to_read_only() {
+        assert!(RemoteHub::new().read_only.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn newer_control_requests_supersede_older_requests() {
+        let hub = RemoteHub::new();
+
+        hub.record_control_request(20);
+        hub.record_control_request(19);
+
+        assert!(hub.control_request_is_current(20));
+        assert!(!hub.control_request_is_current(19));
+    }
+
+    #[test]
+    fn shutdown_waits_for_an_authorized_write_and_blocks_later_writes() {
+        let hub = Arc::new(RemoteHub::new());
+        let generation = hub.activate(9340, 9341);
+        hub.open_pairing_window();
+        let token = hub.pairing_token.lock().expect("pairing token").clone();
+        let (session_id, _) = hub
+            .pair(&token, "Phone".into(), "127.0.0.1:1".into())
+            .expect("pairing should succeed");
+        let (write_started_tx, write_started_rx) = mpsc::channel();
+        let (finish_write_tx, finish_write_rx) = mpsc::channel();
+        let writer_hub = Arc::clone(&hub);
+        let writer = thread::spawn(move || {
+            with_active_remote_session(&writer_hub, generation, session_id, || {
+                write_started_tx.send(()).expect("announce write");
+                finish_write_rx.recv().expect("finish write");
+                Ok(())
+            })
+        });
+
+        write_started_rx.recv().expect("write should start");
+        let (shutdown_finished_tx, shutdown_finished_rx) = mpsc::channel();
+        let shutdown_hub = Arc::clone(&hub);
+        let shutdown = thread::spawn(move || {
+            let _lifecycle = shutdown_hub.lifecycle.lock().expect("lifecycle lock");
+            shutdown_hub.shutdown();
+            shutdown_finished_tx.send(()).expect("announce shutdown");
+        });
+
+        assert!(shutdown_finished_rx
+            .recv_timeout(Duration::from_millis(50))
+            .is_err());
+        finish_write_tx.send(()).expect("release write");
+        assert!(writer.join().expect("writer thread").expect("write result"));
+        shutdown_finished_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("shutdown should finish");
+        shutdown.join().expect("shutdown thread");
+
+        let wrote_after_shutdown = AtomicBool::new(false);
+        assert!(
+            !with_active_remote_session(&hub, generation, session_id, || {
+                wrote_after_shutdown.store(true, Ordering::SeqCst);
+                Ok(())
+            })
+            .expect("authorization check")
+        );
+        assert!(!wrote_after_shutdown.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn shutdown_clears_ports_pairing_and_sessions() {
+        let hub = RemoteHub::new();
+        let generation = hub.activate(9340, 9341);
+        hub.open_pairing_window();
+        let pairing_token = hub.pairing_token.lock().expect("pairing token").clone();
+        let (_, session_token) = hub
+            .pair(&pairing_token, "Phone".into(), "127.0.0.1:5000".into())
+            .expect("device should pair");
+
+        hub.shutdown();
+        let info = hub.info();
+
+        assert!(!info.enabled);
+        assert!(hub.generation.load(Ordering::SeqCst) > generation);
+        assert_eq!(hub.http_port.load(Ordering::SeqCst), 0);
+        assert_eq!(hub.ws_port.load(Ordering::SeqCst), 0);
+        assert!(info.http_url.is_none());
+        assert!(info.ws_url.is_none());
+        assert!(!info.pairing_open);
+        assert!(hub.session_id_for(&session_token).is_none());
+    }
 
     #[test]
     fn publish_does_not_build_payload_without_subscribers() {

--- a/src/components/modals/RemoteControlModal.tsx
+++ b/src/components/modals/RemoteControlModal.tsx
@@ -1,17 +1,18 @@
 import { Smartphone, Wifi, WifiOff } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 
+import { useT } from '../../lib/i18n'
+import { requestRemoteControlPreference } from '../../lib/remoteControlConsent'
 import {
   openRemoteControlPairing,
+  type RemoteControlInfo,
   remoteControlInfo,
   remoteControlRevoke,
-  type RemoteControlInfo,
 } from '../../lib/tauri'
-import { useT } from '../../lib/i18n'
 import { useProjectsStore } from '../../stores/projectsStore'
 import { useUiStore } from '../../stores/uiStore'
-import { Modal } from './Modal'
 import controls from './controls.module.css'
+import { Modal } from './Modal'
 import styles from './RemoteControlModal.module.css'
 
 export function RemoteControlModal() {
@@ -20,6 +21,7 @@ export function RemoteControlModal() {
   const closeModal = useUiStore((state) => state.closeModal)
   const openModal = useUiStore((state) => state.openModal_)
   const setPreferences = useProjectsStore((state) => state.setPreferences)
+  const preferences = useProjectsStore((state) => state.preferences)
   const [info, setInfo] = useState<RemoteControlInfo | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -66,7 +68,7 @@ export function RemoteControlModal() {
             <button
               type="button"
               className={`${controls.btn} ${controls.btnDanger}`}
-              onClick={() => setPreferences({ remoteEnabled: false })}
+              onClick={() => requestRemoteControlPreference(false, preferences, setPreferences, t)}
               disabled={busy}
             >
               <WifiOff size={14} />
@@ -76,7 +78,7 @@ export function RemoteControlModal() {
             <button
               type="button"
               className={`${controls.btn} ${controls.btnPrimary}`}
-              onClick={() => setPreferences({ remoteEnabled: true })}
+              onClick={() => requestRemoteControlPreference(true, preferences, setPreferences, t)}
               disabled={busy}
             >
               <Wifi size={14} />

--- a/src/components/modals/preferences/RemoteControlPage.tsx
+++ b/src/components/modals/preferences/RemoteControlPage.tsx
@@ -1,20 +1,21 @@
 import { ShieldCheck, Smartphone, Wifi, WifiOff } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 
+import { useT } from '../../../lib/i18n'
+import { requestRemoteControlPreference } from '../../../lib/remoteControlConsent'
 import {
   closeRemoteControlPairing,
   openRemoteControlPairing,
+  type RemoteControlInfo,
   remoteControlInfo,
   remoteControlRevoke,
   revokeRemoteControlDevice,
-  type RemoteControlInfo,
 } from '../../../lib/tauri'
-import { useT } from '../../../lib/i18n'
 import { useProjectsStore } from '../../../stores/projectsStore'
-import controls from '../controls.module.css'
-import styles from './RemoteControlPage.module.css'
-import { SettingsSection } from './primitives'
 import { Dropdown } from '../../ui/Dropdown'
+import controls from '../controls.module.css'
+import { SettingsSection } from './primitives'
+import styles from './RemoteControlPage.module.css'
 
 const SESSION_OPTIONS = [900, 3600, 86400]
 
@@ -80,7 +81,14 @@ export function RemoteControlPage() {
           <button
             type="button"
             className={`${controls.btn} ${enabled ? controls.btnDanger : controls.btnPrimary}`}
-            onClick={() => setPreferences({ remoteEnabled: !preferences.remoteEnabled })}
+            onClick={() =>
+              requestRemoteControlPreference(
+                !preferences.remoteEnabled,
+                preferences,
+                setPreferences,
+                t,
+              )
+            }
             disabled={busy}
           >
             {enabled ? t('remote.disable') : t('remote.enable')}

--- a/src/hooks/useRemoteControlService.test.tsx
+++ b/src/hooks/useRemoteControlService.test.tsx
@@ -1,0 +1,177 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listenRemoteMessages: vi.fn(),
+  flushProjectsState: vi.fn(),
+  projectState: {} as Record<string, unknown>,
+  pushToast: vi.fn(),
+  setPreferences: vi.fn(),
+  setRemoteControlEnabled: vi.fn(),
+  setRemoteControlMaxDevices: vi.fn(),
+  setRemoteControlReadOnly: vi.fn(),
+  setRemoteControlSessionExpiry: vi.fn(),
+  setRemoteControlShellInput: vi.fn(),
+}))
+
+vi.mock('../lib/tauri', () => ({
+  listenRemoteMessages: mocks.listenRemoteMessages,
+  setRemoteControlEnabled: mocks.setRemoteControlEnabled,
+  setRemoteControlMaxDevices: mocks.setRemoteControlMaxDevices,
+  setRemoteControlReadOnly: mocks.setRemoteControlReadOnly,
+  setRemoteControlSessionExpiry: mocks.setRemoteControlSessionExpiry,
+  setRemoteControlShellInput: mocks.setRemoteControlShellInput,
+}))
+
+vi.mock('../stores/projectsStore', () => {
+  const useProjectsStore = (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(mocks.projectState)
+  useProjectsStore.getState = () => mocks.projectState
+  return { flushProjectsState: mocks.flushProjectsState, useProjectsStore }
+})
+
+vi.mock('../stores/uiStore', () => {
+  const useUiStore = (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ pushToast: mocks.pushToast })
+  useUiStore.getState = () => ({ pushToast: mocks.pushToast })
+  return { useUiStore }
+})
+
+import { useRemoteControlService } from './useRemoteControlService'
+
+describe('useRemoteControlService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const preferences = {
+      language: 'en',
+      remoteAllowShellInput: false,
+      remoteEnabled: true,
+      remoteMaxDevices: 1,
+      remoteReadOnly: true,
+      remoteSessionExpirySecs: 3_600,
+    }
+    mocks.setPreferences.mockImplementation((patch: Record<string, unknown>) => {
+      Object.assign(preferences, patch)
+    })
+    mocks.projectState = {
+      hydrated: true,
+      preferences,
+      setPreferences: mocks.setPreferences,
+    }
+    mocks.listenRemoteMessages.mockResolvedValue(vi.fn())
+    mocks.flushProjectsState.mockResolvedValue(undefined)
+    mocks.setRemoteControlMaxDevices.mockResolvedValue({})
+    mocks.setRemoteControlSessionExpiry.mockResolvedValue({})
+    mocks.setRemoteControlReadOnly.mockResolvedValue({})
+    mocks.setRemoteControlShellInput.mockResolvedValue({})
+  })
+
+  it('rolls back only remoteEnabled, reports enable failure, and does not retry', async () => {
+    mocks.setRemoteControlEnabled.mockRejectedValueOnce(new Error('ports unavailable'))
+    mocks.setRemoteControlEnabled.mockResolvedValue({ enabled: false })
+
+    const { rerender } = renderHook(() => useRemoteControlService())
+
+    await waitFor(() => {
+      expect(mocks.setPreferences).toHaveBeenCalledWith({ remoteEnabled: false })
+    })
+    expect(mocks.pushToast).toHaveBeenCalledWith({
+      title: 'Remote control could not start',
+      body: expect.stringContaining('ports unavailable'),
+    })
+    expect(mocks.setRemoteControlEnabled).toHaveBeenCalledTimes(2)
+    expect(mocks.setRemoteControlEnabled).toHaveBeenNthCalledWith(1, true, expect.any(Number))
+    expect(mocks.setRemoteControlEnabled).toHaveBeenNthCalledWith(2, false, expect.any(Number))
+    expect(mocks.flushProjectsState).toHaveBeenCalledTimes(1)
+
+    rerender()
+    await waitFor(() => {
+      expect(mocks.setRemoteControlEnabled).toHaveBeenCalledWith(false, expect.any(Number))
+    })
+    rerender()
+
+    expect(
+      mocks.setRemoteControlEnabled.mock.calls.filter(([enabled]) => enabled === true),
+    ).toHaveLength(1)
+    expect(mocks.setPreferences).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed when a security setting cannot be applied', async () => {
+    mocks.setRemoteControlReadOnly.mockRejectedValueOnce(new Error('read-only sync failed'))
+    mocks.setRemoteControlEnabled.mockResolvedValue({ enabled: false })
+
+    renderHook(() => useRemoteControlService())
+
+    await waitFor(() => {
+      expect(mocks.setPreferences).toHaveBeenCalledWith({ remoteEnabled: false })
+    })
+    expect(mocks.setRemoteControlEnabled).toHaveBeenCalledTimes(1)
+    expect(mocks.setRemoteControlEnabled).toHaveBeenCalledWith(false, expect.any(Number))
+    expect(mocks.setRemoteControlEnabled.mock.calls.some(([enabled]) => enabled === true)).toBe(
+      false,
+    )
+    expect(mocks.flushProjectsState).toHaveBeenCalledTimes(1)
+    expect(mocks.pushToast).toHaveBeenCalledWith({
+      title: 'Remote control could not start',
+      body: expect.stringContaining('read-only sync failed'),
+    })
+  })
+
+  it('rolls back when the backend does not report active listeners', async () => {
+    mocks.setRemoteControlEnabled.mockResolvedValue({ enabled: false })
+
+    renderHook(() => useRemoteControlService())
+
+    await waitFor(() => {
+      expect(mocks.setPreferences).toHaveBeenCalledWith({ remoteEnabled: false })
+    })
+    expect(mocks.pushToast).toHaveBeenCalledWith({
+      title: 'Remote control could not start',
+      body: expect.stringContaining('did not report active listeners'),
+    })
+  })
+
+  it('sends disable immediately while an older enable request is still pending', async () => {
+    let resolveEnable!: (value: { enabled: boolean }) => void
+    const enablePending = new Promise<{ enabled: boolean }>((resolve) => {
+      resolveEnable = resolve
+    })
+    mocks.setRemoteControlEnabled.mockImplementation((enabled: boolean) =>
+      enabled ? enablePending : Promise.resolve({ enabled: false }),
+    )
+
+    const { rerender } = renderHook(() => useRemoteControlService())
+    await waitFor(() => {
+      expect(mocks.setRemoteControlEnabled).toHaveBeenCalledWith(true, expect.any(Number))
+    })
+
+    ;(mocks.projectState.preferences as Record<string, unknown>).remoteEnabled = false
+    rerender()
+
+    await waitFor(() => {
+      expect(mocks.setRemoteControlEnabled).toHaveBeenCalledWith(false, expect.any(Number))
+    })
+    expect(
+      mocks.setRemoteControlEnabled.mock.calls.filter(([enabled]) => enabled === false),
+    ).toHaveLength(1)
+
+    resolveEnable({ enabled: true })
+    await enablePending
+  })
+
+  it('reports when the disabled preference cannot be persisted', async () => {
+    mocks.setRemoteControlEnabled.mockRejectedValueOnce(new Error('ports unavailable'))
+    mocks.setRemoteControlEnabled.mockResolvedValue({ enabled: false })
+    mocks.flushProjectsState.mockRejectedValueOnce(new Error('disk unavailable'))
+
+    renderHook(() => useRemoteControlService())
+
+    await waitFor(() => {
+      expect(mocks.pushToast).toHaveBeenCalledWith({
+        title: 'Remote control rollback needs attention',
+        body: expect.stringContaining('disk unavailable'),
+      })
+    })
+    expect(mocks.setPreferences).toHaveBeenCalledWith({ remoteEnabled: false })
+  })
+})

--- a/src/hooks/useRemoteControlService.ts
+++ b/src/hooks/useRemoteControlService.ts
@@ -1,5 +1,6 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
+import { translate } from '../lib/i18n'
 import {
   listenRemoteMessages,
   setRemoteControlEnabled,
@@ -8,9 +9,15 @@ import {
   setRemoteControlSessionExpiry,
   setRemoteControlShellInput,
 } from '../lib/tauri'
-import { translate } from '../lib/i18n'
-import { useProjectsStore } from '../stores/projectsStore'
+import { flushProjectsState, useProjectsStore } from '../stores/projectsStore'
 import { useUiStore } from '../stores/uiStore'
+
+let remoteControlRequestId = Date.now() * 1_000
+
+function nextRemoteControlRequestId(): number {
+  remoteControlRequestId += 1
+  return remoteControlRequestId
+}
 
 export function useRemoteControlService() {
   const hydrated = useProjectsStore((store) => store.hydrated)
@@ -19,17 +26,78 @@ export function useRemoteControlService() {
   const expiry = useProjectsStore((store) => store.preferences.remoteSessionExpirySecs)
   const readOnly = useProjectsStore((store) => store.preferences.remoteReadOnly)
   const allowShellInput = useProjectsStore((store) => store.preferences.remoteAllowShellInput)
+  const syncSequence = useRef(0)
+  const syncQueue = useRef(Promise.resolve())
 
   useEffect(() => {
     if (!hydrated) return
-    const sync = async () => {
-      await setRemoteControlMaxDevices(maxDevices)
-      await setRemoteControlSessionExpiry(expiry)
-      await setRemoteControlReadOnly(readOnly)
-      await setRemoteControlShellInput(allowShellInput)
-      await setRemoteControlEnabled(enabled)
+    const sequence = ++syncSequence.current
+    const requestId = nextRemoteControlRequestId()
+
+    if (!enabled) {
+      void setRemoteControlEnabled(false, requestId).catch((error) => {
+        if (useProjectsStore.getState().preferences.remoteEnabled) return
+        const locale = useProjectsStore.getState().preferences.language
+        useUiStore.getState().pushToast({
+          title: translate(locale, 'remote.disableFailedTitle'),
+          body: translate(locale, 'remote.disableFailedBody', { error: String(error) }),
+        })
+      })
+      return
     }
-    void sync().catch(() => undefined)
+
+    const sync = async () => {
+      if (sequence !== syncSequence.current) return
+
+      try {
+        await Promise.all([
+          setRemoteControlMaxDevices(maxDevices),
+          setRemoteControlSessionExpiry(expiry),
+          setRemoteControlReadOnly(readOnly),
+          setRemoteControlShellInput(allowShellInput),
+        ])
+        if (sequence !== syncSequence.current) return
+
+        const status = await setRemoteControlEnabled(true, requestId)
+        if (sequence !== syncSequence.current) return
+        if (!status.enabled) {
+          throw new Error('Remote control did not report active listeners.')
+        }
+      } catch (error) {
+        if (sequence !== syncSequence.current) return
+        const store = useProjectsStore.getState()
+        if (!store.preferences.remoteEnabled) return
+
+        const stopError = await setRemoteControlEnabled(false, requestId).then(
+          () => null,
+          (stopFailure: unknown) => stopFailure,
+        )
+        if (sequence !== syncSequence.current) return
+
+        const locale = store.preferences.language
+        store.setPreferences({ remoteEnabled: false })
+        const persistenceError = await flushProjectsState().then(
+          () => null,
+          (saveFailure: unknown) => saveFailure,
+        )
+        if (stopError || persistenceError) {
+          useUiStore.getState().pushToast({
+            title: translate(locale, 'remote.rollbackFailedTitle'),
+            body: translate(locale, 'remote.rollbackFailedBody', {
+              error: String(error),
+              rollbackError: String(stopError ?? persistenceError),
+            }),
+          })
+          return
+        }
+        useUiStore.getState().pushToast({
+          title: translate(locale, 'remote.enableFailedTitle'),
+          body: translate(locale, 'remote.enableFailedBody', { error: String(error) }),
+        })
+      }
+    }
+
+    syncQueue.current = syncQueue.current.catch(() => undefined).then(sync)
   }, [allowShellInput, enabled, expiry, hydrated, maxDevices, readOnly])
 
   useEffect(() => {

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -180,6 +180,21 @@ export const en = {
   'remote.statusOff': 'Off',
   'remote.enable': 'Enable remote control',
   'remote.disable': 'Turn off remote control',
+  'remote.confirmEnable':
+    'Enable Remote Control?\n\nAlethe will open HTTP and WebSocket listeners on your local network. Paired devices can view shared terminal output. Paired sessions expire after {expiry}.\n\n{access}',
+  'remote.confirmAccessReadOnly':
+    'Current access is read-only: agent messages and shell input are blocked.',
+  'remote.confirmAccessAgentInput': 'Current access allows agent messages; shell input is blocked.',
+  'remote.confirmAccessShellInput': 'Current access allows agent messages and shell input.',
+  'remote.sessionSeconds': '{seconds} seconds',
+  'remote.enableFailedTitle': 'Remote control could not start',
+  'remote.enableFailedBody': 'Alethe kept remote control off. {error}',
+  'remote.disableFailedTitle': 'Remote control could not stop',
+  'remote.disableFailedBody':
+    'Alethe could not confirm that LAN access stopped. Restart Alethe before continuing. {error}',
+  'remote.rollbackFailedTitle': 'Remote control rollback needs attention',
+  'remote.rollbackFailedBody':
+    'Alethe could not fully save or enforce the disabled state. Restart Alethe and verify Remote Control is off. Startup error: {error}. Rollback error: {rollbackError}',
   'remote.connectedDevices': 'Connected devices',
   'remote.topbarDeviceConnected': '{count} device connected',
   'remote.topbarDevicesConnected': '{count} devices connected',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -180,6 +180,23 @@ export const ptBR: Record<MessageKey, string> = {
   'remote.statusOff': 'Desligado',
   'remote.enable': 'Ligar controle remoto',
   'remote.disable': 'Desligar controle remoto',
+  'remote.confirmEnable':
+    'Ligar o Controle Remoto?\n\nO Alethe abrirá listeners HTTP e WebSocket na sua rede local. Dispositivos pareados poderão ver a saída dos terminais compartilhados. As sessões pareadas expiram após {expiry}.\n\n{access}',
+  'remote.confirmAccessReadOnly':
+    'O acesso atual é somente leitura: mensagens para agentes e entrada de shell estão bloqueadas.',
+  'remote.confirmAccessAgentInput':
+    'O acesso atual permite mensagens para agentes; a entrada de shell está bloqueada.',
+  'remote.confirmAccessShellInput':
+    'O acesso atual permite mensagens para agentes e entrada de shell.',
+  'remote.sessionSeconds': '{seconds} segundos',
+  'remote.enableFailedTitle': 'Não foi possível iniciar o controle remoto',
+  'remote.enableFailedBody': 'O Alethe manteve o controle remoto desligado. {error}',
+  'remote.disableFailedTitle': 'Não foi possível desligar o controle remoto',
+  'remote.disableFailedBody':
+    'O Alethe não conseguiu confirmar que o acesso pela rede local foi encerrado. Reinicie o Alethe antes de continuar. {error}',
+  'remote.rollbackFailedTitle': 'A reversão do controle remoto requer atenção',
+  'remote.rollbackFailedBody':
+    'O Alethe não conseguiu salvar ou aplicar completamente o estado desligado. Reinicie o Alethe e confirme que o Controle Remoto está desligado. Erro de inicialização: {error}. Erro de reversão: {rollbackError}',
   'remote.connectedDevices': 'Dispositivos conectados',
   'remote.topbarDeviceConnected': '{count} dispositivo conectado',
   'remote.topbarDevicesConnected': '{count} dispositivos conectados',

--- a/src/lib/remoteControlConsent.test.ts
+++ b/src/lib/remoteControlConsent.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { type Locale, translate } from './i18n'
+import { requestRemoteControlPreference } from './remoteControlConsent'
+
+function preferences(overrides: Record<string, unknown> = {}) {
+  return {
+    remoteAllowShellInput: false,
+    remoteEnabled: false,
+    remoteReadOnly: true,
+    remoteSessionExpirySecs: 3_600,
+    ...overrides,
+  }
+}
+
+function t(locale: Locale) {
+  return (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) =>
+    translate(locale, key, params)
+}
+
+describe.each(['en', 'pt-BR'] as const)('remote control consent (%s)', (locale) => {
+  it('confirms a false-to-true change with the configured exposure details', () => {
+    const confirm = vi.fn(() => true)
+    const setPreferences = vi.fn()
+
+    expect(
+      requestRemoteControlPreference(true, preferences(), setPreferences, t(locale), confirm),
+    ).toBe(true)
+
+    expect(confirm).toHaveBeenCalledOnce()
+    const message = confirm.mock.calls[0][0]
+    expect(message).toContain(locale === 'en' ? 'local network' : 'rede local')
+    expect(message).toContain(locale === 'en' ? 'terminal output' : 'saída dos terminais')
+    expect(message).toContain(locale === 'en' ? '1 hour' : '1 hora')
+    expect(message).toContain(locale === 'en' ? 'read-only' : 'somente leitura')
+    expect(message).toContain(locale === 'en' ? 'shell input' : 'entrada de shell')
+    expect(setPreferences).toHaveBeenCalledWith({ remoteEnabled: true })
+  })
+
+  it('leaves the preference off when confirmation is cancelled', () => {
+    const setPreferences = vi.fn()
+
+    expect(
+      requestRemoteControlPreference(
+        true,
+        preferences(),
+        setPreferences,
+        t(locale),
+        vi.fn(() => false),
+      ),
+    ).toBe(false)
+    expect(setPreferences).not.toHaveBeenCalled()
+  })
+
+  it('disables immediately without asking for confirmation', () => {
+    const confirm = vi.fn()
+    const setPreferences = vi.fn()
+
+    expect(
+      requestRemoteControlPreference(
+        false,
+        preferences({ remoteEnabled: true }),
+        setPreferences,
+        t(locale),
+        confirm,
+      ),
+    ).toBe(true)
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(setPreferences).toHaveBeenCalledWith({ remoteEnabled: false })
+  })
+})
+
+describe('remote control consent entry points', () => {
+  it.each([
+    ['quick modal', 'src/components/modals/RemoteControlModal.tsx'],
+    ['preferences page', 'src/components/modals/preferences/RemoteControlPage.tsx'],
+  ])('%s routes its enable control through the consent helper', (_, path) => {
+    const source = readFileSync(resolve(path), 'utf8')
+
+    expect(source).toMatch(/import \{ requestRemoteControlPreference \} from/)
+    expect(source).toContain('requestRemoteControlPreference(')
+  })
+})

--- a/src/lib/remoteControlConsent.ts
+++ b/src/lib/remoteControlConsent.ts
@@ -1,0 +1,48 @@
+import type { TFunction } from './i18n'
+import type { Preferences } from './types'
+
+type RemoteConsentPreferences = Pick<
+  Preferences,
+  'remoteAllowShellInput' | 'remoteEnabled' | 'remoteReadOnly' | 'remoteSessionExpirySecs'
+>
+
+type Confirm = (message: string) => boolean
+
+type SetPreferences = (patch: Partial<Preferences>) => void
+
+function sessionExpiryLabel(t: TFunction, seconds: number): string {
+  if (seconds === 900) return t('remote.session900')
+  if (seconds === 3_600) return t('remote.session3600')
+  if (seconds === 86_400) return t('remote.session86400')
+  return t('remote.sessionSeconds', { seconds })
+}
+
+export function remoteControlEnableConfirmation(
+  preferences: RemoteConsentPreferences,
+  t: TFunction,
+): string {
+  const access = preferences.remoteReadOnly
+    ? t('remote.confirmAccessReadOnly')
+    : preferences.remoteAllowShellInput
+      ? t('remote.confirmAccessShellInput')
+      : t('remote.confirmAccessAgentInput')
+
+  return t('remote.confirmEnable', {
+    access,
+    expiry: sessionExpiryLabel(t, preferences.remoteSessionExpirySecs),
+  })
+}
+
+export function requestRemoteControlPreference(
+  nextEnabled: boolean,
+  preferences: RemoteConsentPreferences,
+  setPreferences: SetPreferences,
+  t: TFunction,
+  confirm: Confirm = window.confirm,
+): boolean {
+  if (nextEnabled === preferences.remoteEnabled) return false
+  if (nextEnabled && !confirm(remoteControlEnableConfirmation(preferences, t))) return false
+
+  setPreferences({ remoteEnabled: nextEnabled })
+  return true
+}

--- a/src/lib/tauri/misc.ts
+++ b/src/lib/tauri/misc.ts
@@ -40,8 +40,11 @@ export async function remoteControlRevoke(): Promise<RemoteControlInfo> {
   return invoke<RemoteControlInfo>('remote_control_revoke')
 }
 
-export async function setRemoteControlEnabled(enabled: boolean): Promise<RemoteControlInfo> {
-  return invoke<RemoteControlInfo>('remote_control_set_enabled', { enabled })
+export async function setRemoteControlEnabled(
+  enabled: boolean,
+  requestId: number,
+): Promise<RemoteControlInfo> {
+  return invoke<RemoteControlInfo>('remote_control_set_enabled', { enabled, requestId })
 }
 
 export async function setRemoteControlMaxDevices(maxDevices: number): Promise<RemoteControlInfo> {


### PR DESCRIPTION
## Summary

- require explicit EN/PT-BR confirmation before either Remote Control enable entry point exposes HTTP/WebSocket listeners to the LAN
- show the configured session expiry and whether paired devices can send agent or shell input
- default the backend itself to read-only and require all security-policy setters to succeed before activation
- bind and configure both HTTP and WebSocket listeners before reporting Remote Control enabled
- drop the first listener and leave all public state inactive if the second bind/configuration step fails
- make newer enable/disable requests authoritative so disable bypasses queued synchronization and cannot be undone by an older request finishing later
- revoke pairing/session state and clear advertised ports on shutdown
- serialize authenticated terminal writes against shutdown so no PTY write can occur after disable completes
- immediately flush failed-start preference rollback; show a distinct warning if stop or persistence cannot be confirmed

Closes #137.

## Verification

- `npm test` — 44 files, 295 tests passed
- `npm run build` — production TypeScript/Vite build passed
- `cargo test --lib -- --test-threads=1` — 232 passed, 1 ignored
- `cargo test --lib remote::tests -- --test-threads=1` — 18 passed
- Rust formatting passed
- targeted ESLint: 0 errors; one unchanged `no-explicit-any` warning later in `src/lib/tauri/misc.ts`
- focused Prettier checks passed
- `git diff --check` passed

Regression guard validation: temporarily replacing required `Promise.all(...)` policy synchronization with fail-open `Promise.allSettled(...)` made the read-only synchronization failure test fail as intended. The fail-closed implementation was restored and the focused suite passed again.

## Test coverage

The focused tests cover:

- both activation surfaces remaining wired through informed consent
- EN/PT-BR exposure details and cancellation
- policy-setter rejection preventing listener activation
- inactive listener status triggering rollback
- immediate disable while an older enable request is pending
- durable rollback and honest persistence-failure reporting
- backend read-only defaults
- second-listener bind rollback and port release
- newest-request ordering
- shutdown clearing ports, pairing, and sessions
- PTY write/shutdown serialization and rejection after shutdown

## Compatibility and scope

Remote Control remains off by default. Existing HTTP/WebSocket protocols and ports are unchanged. No external network service or telemetry was added. The Rust implementation uses platform-neutral TCP/atomic/mutex primitives; packaged Windows and macOS smoke testing remains appropriate before release.
