### PR TITLE
docs: publish security and privacy guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@
     ·
     <a href="https://github.com/Kc1t/alethe-agents/issues/new?labels=enhancement">Request Feature</a>
     ·
+    <a href="./SECURITY.md">Security</a>
+    ·
+    <a href="./docs/PRIVACY.md">Privacy</a>
+    ·
     <a href="#contributing">Contribute</a>
   </p>
 </div>
 
 > [!IMPORTANT]
-> Alethe is an early public release. The desktop app is free, open source, and local-first. Optional hosted services, such as sync or cloud backup, may be offered separately later.
+> Alethe is an early public release. The desktop app is free, open source, and local-first, not
+> local-only: update checks and provider usage polling are on by default, while other network features
+> are optional or action-triggered. See the [privacy and data-flow guide](./docs/PRIVACY.md).
 
 <div align="center">
   <img src="./docs/assets/alethe-preview.gif" alt="Alethe multi-agent coding workspace preview" width="760">
@@ -53,6 +59,8 @@ of that, Alethe manages the things agents share: their CLIs, their MCP servers, 
 conversations you move between them.
 
 Cross-platform (Windows, macOS, Linux), local-first, built with Tauri, Rust, React, and `xterm.js`.
+“Local-first” describes workspace persistence, not an internet-free guarantee; see
+[`docs/PRIVACY.md`](./docs/PRIVACY.md) for current network defaults, credentials, and retention.
 
 ## Supported Platforms
 
@@ -114,7 +122,8 @@ registry, npm/pnpm/Volta/fnm/nvm/Bun/Cargo/Scoop/Chocolatey, and can be pointed 
 - Sessions of Claude Code, Codex, and OpenCode resume after a crash or a restart.
 - **Recent chats** lists the conversations of a pane's working directory and reopens any of them.
 - A Claude Code conversation can be **handed off to Codex** (and back) through a locally redacted
-  context packet — no copy-pasting the thread by hand.
+  context packet — no copy-pasting the thread by hand. Redaction is best effort, so review the packet
+  before starting the target agent.
 - Scrollback is persisted per PTY, so reattaching shows what happened before.
 
 **Manage what the agents share**
@@ -136,9 +145,11 @@ registry, npm/pnpm/Volta/fnm/nvm/Bun/Cargo/Scoop/Chocolatey, and can be pointed 
 - Todos per project, isolated profiles, local backup export/import, 14 UI and terminal themes,
   EN and pt-BR.
 - **Remote Control**: an authenticated LAN web view, paired by QR code, to follow and answer agents
-  from your phone.
+  from your phone. It is off by default and uses unencrypted HTTP/WebSocket transport on the LAN, so
+  enable it only on a trusted network.
 - Spotify Now Playing, using your own Spotify app credentials in **Preferences ▸ Spotify** with
-  `http://127.0.0.1:8888/callback` as the redirect URI.
+  `http://127.0.0.1:8888/callback` as the redirect URI. Current releases store those credentials in
+  local profile files; see the privacy guide before exporting or sharing profile data.
 
 ## Core Concepts
 
@@ -163,10 +174,10 @@ Use the published installers from [Releases](https://github.com/Kc1t/alethe-agen
 
 > [!WARNING]
 > Windows builds are **not code-signed yet**, so Defender may flag `alethe.exe` as
-> `Trojan:Win32/Bearfoos.A!ml` and quarantine it. **This is a false positive** — the `!ml` suffix
-> means a machine-learning heuristic, not a malware signature, and Alethe trips it by doing what a
-> terminal multiplexer must do: spawn child processes, create PTYs, write into them, and self-update
-> from an unsigned binary.
+> `Trojan:Win32/Bearfoos.A!ml` and quarantine it. The `!ml` suffix denotes a machine-learning
+> heuristic rather than a publisher signature, and terminal-multiplexer behavior such as spawning
+> child processes and creating PTYs can produce false positives. Verify that the download came from
+> the official Releases page; do not bypass a warning for an artifact from another source.
 
 To recover it: **Windows Security → Virus & threat protection → Protection history → Actions →
 Restore**, then add an exclusion for `%LOCALAPPDATA%\Alethe` (and `src-tauri/target` if you build
@@ -291,6 +302,8 @@ offered separately. The **Alethe** name, logo, and official branding are reserve
 
 ## Community
 
+- Security reports: [`SECURITY.md`](SECURITY.md)
+- Privacy and data flows: [`docs/PRIVACY.md`](docs/PRIVACY.md)
 - Maintainer: [Kc1t](https://github.com/Kc1t)
 - Project: <https://github.com/Kc1t/alethe-agents>
 - Bugs and feature requests: <https://github.com/Kc1t/alethe-agents/issues>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@
 > [!IMPORTANT]
 > Alethe is an early public release. The desktop app is free, open source, and local-first, not
 > local-only: update checks and provider usage polling are on by default, while other network features
-> are optional or action-triggered. See the [privacy and data-flow guide](./docs/PRIVACY.md).
+> are optional or action-triggered. Manual GitHub Gist Sync is already available; first-party hosted
+> sync or cloud backup may be offered separately later. See the
+> [privacy and data-flow guide](./docs/PRIVACY.md).
 
 <div align="center">
   <img src="./docs/assets/alethe-preview.gif" alt="Alethe multi-agent coding workspace preview" width="760">
@@ -146,7 +148,8 @@ registry, npm/pnpm/Volta/fnm/nvm/Bun/Cargo/Scoop/Chocolatey, and can be pointed 
   EN and pt-BR.
 - **Remote Control**: an authenticated LAN web view, paired by QR code, to follow and answer agents
   from your phone. It is off by default and uses unencrypted HTTP/WebSocket transport on the LAN, so
-  enable it only on a trusted network.
+  enable it only on a trusted network. Clean profiles are read-only; answering agents requires a
+  separate input opt-in, and shell input has its own additional opt-in.
 - Spotify Now Playing, using your own Spotify app credentials in **Preferences ▸ Spotify** with
   `http://127.0.0.1:8888/callback` as the redirect URI. Current releases store those credentials in
   local profile files; see the privacy guide before exporting or sharing profile data.
@@ -230,7 +233,7 @@ is already running, the existing window is focused. The command lands in `~/.loc
 - [x] Releases for Windows, Linux, and macOS.
 - [ ] Windows release signing and macOS notarization.
 - [ ] Broader Linux/macOS validation on real machines.
-- [ ] Optional cloud sync/backup.
+- [ ] First-party hosted cloud sync/backup (manual GitHub Gist Sync is already available).
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security policy
+
+## Supported versions
+
+Alethe does not currently publish a fixed version-support window. Security work is evaluated against
+the current `main` branch and the latest published release. Before reporting, please check whether the
+behavior still exists in one of those versions and include the exact version or commit you tested.
+This wording is not a promise that every historical release will receive a fix.
+
+## Report a vulnerability privately
+
+**Do not open a public issue, discussion, or pull request for a suspected vulnerability.** Email the
+maintainers at [contact@kc1t.com](mailto:contact@kc1t.com), the project contact already published in
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+Include as much of the following as is safe to share:
+
+- the affected Alethe version or commit, operating system, and installation method;
+- the affected feature and the security impact you believe is possible;
+- prerequisites, a minimal reproduction, and whether the behavior works with default settings;
+- relevant logs or screenshots after removing tokens, credentials, personal paths, repository
+  contents, and other private data;
+- any workaround you have tested; and
+- how you would like to be credited, or that you prefer to remain anonymous.
+
+Please use a concise proof of concept and do not access data or systems you do not own or have
+permission to test. Do not send live credentials. If the initial report itself needs additional
+protection, say so in the first email and coordinate a safer transfer method before sending sensitive
+attachments.
+
+The maintainers will assess the report and coordinate next steps when they can. This project does not
+currently promise an acknowledgement, remediation, or disclosure deadline.
+
+## Coordinated disclosure
+
+Please keep the report private while it is being assessed and allow the maintainers a reasonable
+opportunity to investigate and prepare a fix. Coordinate the timing and content of any public
+disclosure before publishing details. The maintainers may ask for validation of a candidate fix and
+will discuss credit with you. These expectations do not authorize testing against third-party systems
+or other users.
+
+## Scope and security boundaries
+
+Reports about Alethe's own code, packaging, update flow, local data handling, process execution,
+embedded web content, or integrations are in scope. Problems that exist only in a coding-agent CLI,
+MCP server, package manager, operating-system webview, or remote service should also be reported to
+that upstream vendor; please still contact Alethe privately if Alethe's integration makes the impact
+materially worse.
+
+Alethe is a terminal and coding-agent workspace. It intentionally starts subprocesses, gives terminal
+sessions access to the selected working directory and inherited environment, and can connect to
+services described in the [privacy and data-flow guide](docs/PRIVACY.md). A process doing what the
+user explicitly asked is not by itself a vulnerability, but unintended privilege, origin, or data
+exposure can be.
+
+The production Tauri configuration currently has no Content Security Policy (`csp: null`). A CSP,
+when configured, is defense in depth for web content; it is not a containment boundary for privileged
+Tauri commands. Please do not rely on CSP alone when evaluating command authorization or untrusted
+content.
+
+## Bugs, questions, and feature requests
+
+For crashes, setup help, ordinary bugs, documentation problems, and feature requests that do not
+contain a security concern, use the public
+[GitHub issue tracker](https://github.com/Kc1t/alethe-agents/issues). See
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the requested reproduction and contribution details.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -2,7 +2,7 @@
 
 Alethe is a desktop workspace for running coding agents and shells side by side. It turns terminals into persistent workspace units: each pane has its own cwd, PTY, scrollback, tabs, layout state, and local resume data.
 
-The app is local-first. Projects, preferences, layouts, scrollback, sessions, and Spotify credentials stay on the user's machine unless an optional cloud service is added later.
+The app is local-first, not local-only. Its primary workspace state is stored on the user's machine, while update checks, provider usage polling, optional integrations, embedded web content, LAN remote control, and coding-agent subprocesses have the data flows documented in the [privacy guide](PRIVACY.md). See the repository [security policy](../SECURITY.md) for private vulnerability reporting.
 
 ## What It Provides
 
@@ -58,7 +58,15 @@ Typical files include:
 - `profiles/<profileId>/projects.json`: projects, groups, workspace state, preferences, and CLI paths.
 - `profiles/<profileId>/scrollback/`: terminal scrollback snapshots.
 - `profiles/<profileId>/spotify_tokens.json`: local Spotify token cache, when configured.
-- `profiles/<profileId>/spawn.log`: local spawn and diagnostic log.
+- `profiles/<profileId>/github_sync.json`: GitHub Sync token and metadata, when configured.
+- `profiles/<profileId>/spawn.log`: command, launcher, path-preview, timing, and PTY diagnostics.
+- `profiles/<profileId>/handoffs/` and `mcp/`: temporary handoff packets, registry cache, and MCP backups.
+- root-level `logs/`: telemetry, crash, frontend, resource, and lifecycle diagnostics shared by the
+  installation.
+
+Retention, export exclusions, plaintext credential storage, and deletion limits are documented in
+[`PRIVACY.md`](PRIVACY.md); “local” does not mean every local artifact is automatically included in a
+profile backup or removed from external copies.
 
 ## Development
 
@@ -79,4 +87,4 @@ src-tauri/target/release/bundle/
 
 Alethe is currently focused on the local desktop app. Windows is the most tested platform, while Linux and macOS builds are supported by the release workflow and need broader real-machine validation.
 
-Cloud sync, hosted backup, billing, and online services are intentionally separate from the local app.
+Alethe does not require an Alethe cloud account. Current first-party and third-party network surfaces, their defaults, and local retention/deletion behavior are documented in [`PRIVACY.md`](PRIVACY.md).

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,168 @@
+# Privacy and data flow
+
+This document describes the behavior of the current Alethe `main` branch. It is a technical data-flow
+guide, not a policy for Anthropic, OpenAI, Google, GitHub, Spotify, Discord, an MCP publisher, or any
+other third party.
+
+## Local-first, not local-only
+
+Alethe is **local-first, not local-only**. Workspace state is stored on the user's machine and Alethe
+does not require an Alethe cloud account, but the app has automatic and user-triggered network
+surfaces. Coding-agent CLIs and other tools started inside its terminals can also use the network
+under their own terms and configuration.
+
+There is no first-party Alethe analytics uploader in the audited source. That does not make the app
+network-free: update checks and provider usage polling are on by default, and other integrations
+connect when enabled or used.
+
+## Local data, retention, export, and deletion
+
+Alethe uses Tauri's platform-specific application local-data directory. It keeps a profile registry at
+the root and isolates most state under `profiles/<profileId>/`. Typical data includes:
+
+- `projects.json`: projects, groups, terminal and layout state, preferences, custom CLI paths, recent
+  items, and Spotify client ID/client secret if entered in Preferences;
+- `scrollback/*.bin`: terminal scrollback snapshots;
+- `activity-stats.json`: local activity summaries;
+- `spawn.log`: process-launch and suspension diagnostics, including command/launcher representations,
+  a PATH preview, identifiers, and timing data;
+- `spotify_tokens.json` and `github_sync.json`: integration credentials and sync metadata when those
+  integrations are connected;
+- `handoffs/<handoffId>/context.md`: a temporary cross-agent context packet when a handoff is used;
+- `mcp/registry-cache.json` and MCP backup files: registry results and backups made while managing
+  agent configuration; and
+- root-level `logs/`: crash and frontend errors, resource snapshots, lifecycle messages, and
+  `telemetry.jsonl` shared by the application installation.
+
+Alethe also reads or modifies data outside its own directory when a feature requires it: repositories,
+agent session histories, agent configuration and credential stores, MCP/skill directories, user-chosen
+todo or export locations, and operating-system credential stores. The embedded browser uses a private
+webview, but the operating-system webview and sites may still maintain process-level caches or other
+state outside Alethe's profile directory.
+
+### Retention
+
+Most profile data remains until it is overwritten, the profile is deleted, or app data is reset.
+There is no general time-based retention policy. Crash and frontend errors keep at most 20 files per
+prefix, and the newest 500 event traces are retained in memory. Profile `spawn.log`, root
+`resource.log`, `app-events.log`, and `telemetry.jsonl` are append-only and currently have no rotation
+or size cap. Scrollback and logs may contain commands, output, paths, timing/resource facts, error
+messages, or payloads supplied by app features.
+
+### Export and deletion controls
+
+- **Backup export/import** writes a ZIP to a location the user chooses. A profile export includes the
+  profile tree, including persisted integration secrets and handoff/MCP artifacts, except `.log` and
+  `.tmp` files and embedded-webview runtime data. Profile `spawn.log` is therefore excluded. Treat
+  exported backups as sensitive and delete old copies yourself.
+- **Log export** writes the files in the root `logs/` directory to a user-chosen ZIP. Review and redact
+  it before sharing. It does not include profile `spawn.log`.
+- **Delete profile** removes that profile directory; Alethe prevents deletion of the last profile.
+- **Reset/factory reset** removes active-profile data or, for the full reset, the app local-data root.
+  The reset is best effort while files are open, and the app should be relaunched afterward.
+- **Spotify disconnect** removes `spotify_tokens.json`. **GitHub Sync logout** clears its stored token
+  but leaves non-secret sync metadata in `github_sync.json`.
+
+Deleting Alethe data does not delete copies already exported or synced, repositories, coding-agent
+histories/configuration, operating-system credentials, remote GitHub Gists, or data held by external
+services. Remove those at their source as well.
+
+## Secrets and credentials
+
+Alethe does not currently move all integration secrets into an operating-system keyring:
+
+- Spotify client ID/client secret are persisted as preferences in `projects.json`; Spotify access and
+  refresh tokens are JSON fields in `spotify_tokens.json`.
+- A GitHub personal access token is a JSON field in `github_sync.json`.
+- Profile backups can contain those files and values.
+- MCP credentials remain in the agent configuration files where the user adds them. Alethe masks
+  environment values in normal MCP views and reveals one value only on explicit request, but config
+  files and Alethe-created MCP backups can still contain plaintext secrets.
+- Claude usage polling reads a token from `CLAUDE_OAUTH_TOKEN`, Claude Code's credentials file, or the
+  OS keyring. Antigravity usage polling reads the `agy` credential from the OS keyring. Alethe uses
+  these values for the request and does not intentionally copy them into Alethe profile persistence.
+- Codex usage is requested through a short-lived `codex app-server` subprocess, so Codex remains
+  responsible for its own authentication storage.
+
+File protection therefore depends on OS account permissions and the security of any destination to
+which a backup is copied. Do not place profile data, exports, logs, or agent configs in a public or
+untrusted location.
+
+## Local telemetry and diagnostics
+
+The backend subscribes to Alethe's internal event bus on every launch. Each event, including its
+arbitrary JSON `data` payload, is appended to `logs/telemetry.jsonl`; counts and selected numeric
+fields are also kept in memory, with the newest 500 event traces retained in memory. The current
+source contains no telemetry upload client or first-party analytics endpoint.
+
+Crash, frontend, resource, app-lifecycle, and spawn diagnostics are also local. They can include stack
+traces, process/resource facts, paths, messages, command/launcher representations, PATH previews,
+identifiers, and terminal launch timings. Log export is a manual local operation; Alethe does not
+automatically send the archive. Inspect both the archive and any separately shared `spawn.log` before
+attaching them to an issue or email.
+
+## Network and process inventory
+
+"Default" below means a clean profile on the current `main` branch. A feature being visible or enabled
+does not necessarily mean it sends a request before the stated trigger.
+
+| Surface | Exact current default | What happens and where data goes |
+|---|---|---|
+| Automatic update check | **On** | Once app state hydrates, Alethe checks `https://github.com/Kc1t/alethe-agents/releases/latest/download/latest.json`. Download and installation happen only after the user accepts an available update; updater artifacts are signature-checked by the configured Tauri updater key. This is separate from platform publisher signing: current Windows installers are not code-signed and macOS builds are not notarized. There is currently no preference that disables the startup check. |
+| Provider usage polling | **On** | While the title bar is mounted, Alethe schedules Claude, Codex, and Antigravity usage reads shortly after startup and every five minutes; ticks are skipped while the window is unfocused/hidden. The three topbar indicators default visible. Claude sends its bearer credential to `https://api.anthropic.com/api/oauth/usage`; Antigravity sends its bearer credential to `https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels`; Codex is queried through a short-lived `codex app-server` subprocess. The current visibility preferences hide indicators but do not gate the polling effects. |
+| Discord Rich Presence | **On** | Every 30 seconds, Alethe sends generic activity text (Alethe and the current app view, not project names) to the local Discord desktop IPC client. Discord controls any onward network publication under the Discord account's settings and terms. It can be disabled in Preferences. |
+| Spotify Now Playing | **Off / unconfigured** | No Spotify request succeeds on a clean profile because credentials and OAuth tokens are absent. Connecting opens Spotify authorization, temporarily listens only on `127.0.0.1:8888`, exchanges/refreshes tokens at `accounts.spotify.com`, and polls current or recent playback at `api.spotify.com` when a Now Playing widget is enabled. Returned cover-image URLs may cause requests to Spotify's image host. |
+| GitHub Sync | **Off / disconnected; manual** | Entering a token validates it against `https://api.github.com/user`. Explicit Push uploads `projects.json` and, if present, `activity-stats.json` to a secret GitHub Gist; explicit Pull downloads them. A secret Gist is access-controlled by GitHub, not end-to-end encrypted by Alethe. Alethe does not periodically push or pull. |
+| MCP registry | **MCP feature on; search on demand** | Local agent configs are scanned without registry traffic. Searching the add flow queries `https://registry.modelcontextprotocol.io/v0/servers` and caches the first page of up to 20 search terms under the profile. Adding a result writes agent configuration; package runtimes or remote URLs connect later when an agent/MCP client runs them. |
+| MCP health checks and server tools | **On demand** | A Check action launches the selected coding-agent CLI so that CLI can test configured servers. The generic health probe may start a user-configured server command and probe it on an ephemeral loopback port. Those subprocesses and MCP servers can contact their configured hosts. |
+| Embedded web content | **Browser feature on; no page open** | A page is loaded only after the user adds a URL. The desktop build creates an incognito native webview with autofill off; JavaScript is **on by default** for each pane. The visited site and all resources it embeds receive ordinary network requests and can observe data normally exposed by the OS webview and network. Incognito mode is not anonymity and does not stop the site from collecting data. |
+| LAN Remote Control | **Off** | When enabled, Alethe binds plain HTTP and WebSocket listeners to the detected LAN interface, choosing ports in `9340–9360` (WebSocket starts at the next port range). Pairing is opened explicitly for two minutes and uses a token; clean-profile limits are one device, one-hour sessions, read-only access on, and shell input off. Terminal/workspace metadata and scrollback are then available to authenticated paired devices. Use only on a trusted LAN; the transport is not TLS-encrypted. |
+| Agent-event hook listener | **On, loopback only** | At backend startup Alethe listens on the first available address from `127.0.0.1:9123–9143`. Requests require an in-memory `X-Alethe-Token`; Alethe writes a temporary hook configuration only when an agent workflow requests it. Hook payloads can feed the local event bus and therefore local telemetry. |
+| AI Memory bridge | **Off** | The feature default is disabled. Detection, when requested, checks the local `ai-memory` executable and `127.0.0.1:49374`; configured agent sessions run the third-party `ai-memory mcp` subprocess over stdio. Its own storage and network behavior belong to that tool. |
+| Development server | **Development only** | `npm run dev` and `npm run app` start Vite with hot-module reload on a loopback development port. This server and development CSP are not part of packaged releases; do not expose the development server to an untrusted network. |
+| Git remotes, installers, and external links | **On demand** | Clone, fetch/pull/push, agent install/update/uninstall, and opened links run only after a user action. Alethe delegates to Git, package managers/vendor installers, or the system browser; those tools contact the user-selected remote or their package/vendor services and apply their own credential and telemetry rules. |
+
+## Coding-agent CLIs and other subprocesses
+
+Claude Code, Codex, Copilot, Antigravity, OpenCode, Mimo, Freebuff, shells, Git, package managers, MCP
+servers, Graphify, and user-entered commands are separate processes. Alethe supplies their command-line
+arguments, selected working directory, PTY input/output, and an inherited or constructed environment.
+They may read repositories and home-directory configuration, use credentials they own, retain their
+own histories, and contact provider or tool endpoints. Alethe's local-first design does not proxy,
+block, audit, or make those subprocesses local-only. Review each tool's permissions, privacy terms,
+configuration, and unrestricted/approval mode before launching it.
+
+## Handoff artifacts and redaction limits
+
+A Claude-to-Codex or Codex-to-Claude handoff reads the selected provider's local session history and
+builds an editable Markdown context packet. It can include user and assistant messages, clipped tool
+calls/output, working-directory and Git metadata, and the source session identifier. Before showing
+the draft, Alethe applies regular-expression redaction for several common token, credential, header,
+and private-key patterns.
+
+That redaction is best effort, not a guarantee. Unusual secrets, confidential prose, source code,
+paths, identifiers, or credentials split across text can remain. Review and edit the draft before
+starting the target agent. Materializing a handoff writes
+`handoffs/<handoffId>/context.md`; Alethe requests cleanup after the first target turn or when the pane
+closes, but a crash or interrupted flow can leave the file behind until manual/profile deletion. The
+target agent then reads the packet and may send its contents to that agent's provider under the
+provider's terms.
+
+## Embedded content, CSP, and privileged commands
+
+Remote pages are placed in separate incognito native webviews, while the main Alethe UI invokes the
+Tauri backend. The production configuration currently sets `csp` to `null`. A Content Security Policy,
+when configured, is **defense in depth**, not privileged-command containment and not an authorization
+boundary for Tauri commands. Treat content from web pages, repositories, terminal output, handoff
+packets, agent histories, and MCP metadata as untrusted regardless of CSP.
+
+## Third-party services
+
+External requests disclose ordinary connection metadata such as IP address, time, TLS and HTTP
+metadata, plus the request-specific account credential or content described above. Third parties set
+their own retention, logging, training, and deletion rules. Consult and configure the relevant
+provider before enabling an integration or launching a tool.
+
+For a suspected security problem, follow [`SECURITY.md`](../SECURITY.md). For a non-security bug or
+documentation correction, use the
+[public issue tracker](https://github.com/Kc1t/alethe-agents/issues).

--- a/src/lib/documentation.test.ts
+++ b/src/lib/documentation.test.ts
@@ -1,0 +1,80 @@
+import overview from '../../docs/OVERVIEW.md?raw'
+import privacy from '../../docs/PRIVACY.md?raw'
+import readme from '../../README.md?raw'
+import security from '../../SECURITY.md?raw'
+
+const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+
+describe('security and privacy documentation', () => {
+  it('keeps the security reporting contract private and appropriately scoped', () => {
+    const text = normalize(security)
+
+    expect(text).toContain('Supported versions')
+    expect(text).toContain('contact@kc1t.com')
+    expect(text).toContain('Do not open a public issue')
+    expect(text).toContain('Coordinated disclosure')
+    expect(text).toContain('Bugs, questions, and feature requests')
+    expect(text).toContain('does not currently promise')
+    expect(text).toContain('defense in depth')
+    expect(text).toContain('not a containment boundary for privileged Tauri commands')
+  })
+
+  it('documents retention, secrets, subprocesses, and every major network default', () => {
+    const text = normalize(privacy)
+
+    for (const required of [
+      'Local-first, not local-only',
+      'Local data, retention, export, and deletion',
+      'Secrets and credentials',
+      'Local telemetry and diagnostics',
+      'Network and process inventory',
+      'Coding-agent CLIs and other subprocesses',
+      'Handoff artifacts and redaction limits',
+      'Embedded content, CSP, and privileged commands',
+      'Automatic update check | **On**',
+      'Provider usage polling | **On**',
+      'Discord Rich Presence | **On**',
+      'Spotify Now Playing | **Off / unconfigured**',
+      'GitHub Sync | **Off / disconnected; manual**',
+      'MCP registry | **MCP feature on; search on demand**',
+      'Embedded web content | **Browser feature on; no page open**',
+      'LAN Remote Control | **Off**',
+      'Agent-event hook listener | **On, loopback only**',
+      'AI Memory bridge | **Off**',
+      'Development server | **Development only**',
+      'no rotation or size cap',
+      'no telemetry upload client',
+      'at most 20 files per prefix',
+      'does not include profile `spawn.log`',
+      'current Windows installers are not code-signed',
+      'JavaScript is **on by default**',
+      'defense in depth',
+      'not privileged-command containment',
+    ]) {
+      expect(text, `missing privacy statement: ${required}`).toContain(required)
+    }
+  })
+
+  it('rejects broad internet-free claims', () => {
+    const docs = normalize(`${readme}\n${overview}\n${security}\n${privacy}`)
+
+    expect(docs).not.toMatch(/\bnever connects? (?:to )?(?:the )?internet\b/i)
+    expect(docs).not.toMatch(/\bdoes not connect (?:to )?(?:the )?internet\b/i)
+    expect(docs).not.toMatch(/\bno (?:external )?network (?:access|traffic|connections?)\b/i)
+  })
+
+  it('keeps top-level local-first claims linked to concrete qualifications', () => {
+    const readmeText = normalize(readme)
+    const overviewText = normalize(overview)
+
+    expect(readmeText).toContain(
+      '“Local-first” describes workspace persistence, not an internet-free guarantee',
+    )
+    expect(readmeText).toContain('update checks and provider usage polling are on by default')
+    expect(readmeText).toContain('Redaction is best effort')
+    expect(readmeText).toContain('unencrypted HTTP/WebSocket transport')
+    expect(readmeText).not.toContain('This is a false positive')
+    expect(overviewText).toContain('root-level `logs/`')
+    expect(overviewText).toContain('plaintext credential storage')
+  })
+})

--- a/src/lib/documentation.test.ts
+++ b/src/lib/documentation.test.ts
@@ -71,8 +71,10 @@ describe('security and privacy documentation', () => {
       '“Local-first” describes workspace persistence, not an internet-free guarantee',
     )
     expect(readmeText).toContain('update checks and provider usage polling are on by default')
+    expect(readmeText).toContain('Manual GitHub Gist Sync is already available')
     expect(readmeText).toContain('Redaction is best effort')
     expect(readmeText).toContain('unencrypted HTTP/WebSocket transport')
+    expect(readmeText).toContain('Clean profiles are read-only')
     expect(readmeText).not.toContain('This is a false positive')
     expect(overviewText).toContain('root-level `logs/`')
     expect(overviewText).toContain('plaintext credential storage')


### PR DESCRIPTION
## Summary

- add a private vulnerability-reporting policy with supported-version, response, coordinated-disclosure, scope, and security-model guidance
- add a current-`main` privacy/data-flow inventory covering local persistence, retention, exports, deletion limits, plaintext credentials, diagnostics, telemetry, subprocesses, and network defaults
- qualify top-level “local-first” language in README and overview so it is not read as an internet-free guarantee
- disclose Remote Control’s unencrypted LAN transport, best-effort handoff redaction, current Spotify storage, unsigned/notarized package state, and exact diagnostic-log boundaries
- add regression tests spanning README, overview, SECURITY.md, and PRIVACY.md to reject broad network-free claims and preserve important default/retention disclosures

Closes #138.

## Verification

- `npm test -- src/lib/documentation.test.ts` — 4 passed
- `npm test` — 43 files, 286 tests passed
- `npm run build` — production TypeScript/Vite build passed
- targeted ESLint passed
- focused Prettier check passed
- `git diff --check` passed

## Accuracy and scope

This documentation intentionally describes behavior on the current `main` branch, including known limitations that other open PRs may later change:

- production CSP is currently `null`
- Spotify and GitHub Sync credentials are currently stored in profile JSON
- telemetry persists arbitrary event data and has no size cap
- LAN Remote Control is off by default but uses plain HTTP/WebSocket when enabled
- provider usage polling and update checks run by default

The wording should be updated only when those behavioral changes merge and ship; this PR does not present pending hardening work as released behavior.
