### PR TITLE
fix(profiles): align account actions and preserve display name

### DIFF
--- a/src/components/modals/ProfilesModal.module.css
+++ b/src/components/modals/ProfilesModal.module.css
@@ -62,6 +62,9 @@
   color: var(--accent);
   background: var(--accent-faint);
 }
+.createIcon svg {
+  display: block;
+}
 .createCopy {
   min-width: 0;
 }
@@ -169,6 +172,20 @@
 }
 .renameRow {
   flex: 1;
+}
+.createRow button,
+.actions button,
+.renameRow button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.createRow button svg,
+.actions button svg,
+.renameRow button svg {
+  display: block;
+  flex: 0 0 auto;
 }
 .renameRow input {
   min-width: 160px;

--- a/src/components/modals/ProfilesModal.tsx
+++ b/src/components/modals/ProfilesModal.tsx
@@ -13,23 +13,28 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { saveFile } from '../../lib/dialog'
 import { useT } from '../../lib/i18n'
-import { DEFAULT_PROFILE_IMAGE_URL, getProfileImageUrl, getProfileInitial } from '../../lib/profile'
+import {
+  DEFAULT_PROFILE_IMAGE_URL,
+  getProfileAccountName,
+  getProfileImageUrl,
+  getProfileInitial,
+} from '../../lib/profile'
 import {
   createProfile,
   deleteProfile,
   exportProfileBackup,
   listProfileSummaries,
+  type ProfileSummary,
   renameProfile,
   setActiveProfile,
   suspendPty,
-  type ProfileSummary,
 } from '../../lib/tauri'
 import { useProjectsStore } from '../../stores/projectsStore'
 import { useTerminalsStore } from '../../stores/terminalsStore'
 import { useUiStore } from '../../stores/uiStore'
 import { Avatar } from '../ui/Avatar'
-import { Modal } from './Modal'
 import controls from './controls.module.css'
+import { Modal } from './Modal'
 import styles from './ProfilesModal.module.css'
 
 type BusyAction = null | 'load' | 'create' | 'rename' | 'switch' | 'backup' | 'delete'
@@ -110,7 +115,16 @@ export function ProfilesModal() {
       })),
     [activeProfileId, preferences.profileImageUrl, profiles, projects],
   )
-  const items = summaries.length > 0 ? summaries : fallbackSummaries
+  const sourceItems = summaries.length > 0 ? summaries : fallbackSummaries
+  const items = sourceItems.map((profile) => ({
+    ...profile,
+    name: getProfileAccountName({
+      profileId: profile.id,
+      profileName: profile.name,
+      activeProfileId,
+      displayName: preferences.displayName,
+    }),
+  }))
   const activeProfile =
     items.find((profile) => profile.is_active || profile.id === activeProfileId) ?? null
   const currentPtyIds = projects.flatMap((project) =>

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { getProfileAccountName } from './profile'
+
+describe('getProfileAccountName', () => {
+  it('uses the active display name instead of the default profile placeholder', () => {
+    expect(
+      getProfileAccountName({
+        profileId: 'default',
+        profileName: 'Default',
+        activeProfileId: 'default',
+        displayName: 'luca',
+      }),
+    ).toBe('luca')
+  })
+
+  it('keeps an explicitly renamed profile name', () => {
+    expect(
+      getProfileAccountName({
+        profileId: 'default',
+        profileName: 'Work',
+        activeProfileId: 'default',
+        displayName: 'luca',
+      }),
+    ).toBe('Work')
+  })
+
+  it('does not apply the active display name to another profile', () => {
+    expect(
+      getProfileAccountName({
+        profileId: 'client',
+        profileName: 'Default',
+        activeProfileId: 'default',
+        displayName: 'luca',
+      }),
+    ).toBe('Default')
+  })
+
+  it('keeps the placeholder when the display name is empty', () => {
+    expect(
+      getProfileAccountName({
+        profileId: 'default',
+        profileName: 'Default',
+        activeProfileId: 'default',
+        displayName: '   ',
+      }),
+    ).toBe('Default')
+  })
+})

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,7 +1,27 @@
-import type { Preferences } from './types'
 import defaultProfileImage from '../assets/theme-icons/dark.png'
+import type { Preferences } from './types'
 
 export const DEFAULT_PROFILE_IMAGE_URL = defaultProfileImage
+
+type ProfileAccountNameInput = {
+  profileId: string
+  profileName: string
+  activeProfileId: string
+  displayName: string
+}
+
+export function getProfileAccountName({
+  profileId,
+  profileName,
+  activeProfileId,
+  displayName,
+}: ProfileAccountNameInput): string {
+  const activeDisplayName = displayName.trim()
+  const isDefaultPlaceholder = profileId === 'default' && profileName === 'Default'
+  return profileId === activeProfileId && isDefaultPlaceholder && activeDisplayName
+    ? activeDisplayName
+    : profileName
+}
 
 export function getProfileImageUrl(preferences: Preferences): string | null {
   const url = preferences.profileImageUrl.trim()


### PR DESCRIPTION
Closes #149.

Manage Accounts had two small inconsistencies: its action icons were aligned to the text baseline, and a migrated built-in profile could still appear as `Default` even when the active account had a real display name.

This aligns the Create Account, Rename, Delete, Save, and Cancel actions with a consistent icon gap and centers the plus inside the empty account avatar. It also uses the active display name when, and only when, the built-in `default` profile still has the untouched `Default` placeholder. Explicitly renamed profiles and other accounts are left alone.

### Before

The original modal has uneven icon alignment, almost no space between action icons and labels, and an off-center plus in the empty account avatar.

![Before](https://raw.githubusercontent.com/lucapohl-angel/alethe-agents/f3b4f4784094f667343f22e892a6864ccff753c0/profile-actions/before.png)

### After

The card and active-account label use the same `luca` display name shown elsewhere.

![After](https://raw.githubusercontent.com/lucapohl-angel/alethe-agents/f3b4f4784094f667343f22e892a6864ccff753c0/profile-actions/after.png)

Clicking Rename now starts with `luca` instead of `Default`.

![Rename](https://raw.githubusercontent.com/lucapohl-angel/alethe-agents/f3b4f4784094f667343f22e892a6864ccff753c0/profile-actions/rename.png)

Tested on Garuda Linux:

- `npm test` — 301 tests passed
- `npm run build`
- changed-file ESLint and Prettier checks
- AppImage packaging tests — 2 tests passed
- rebuilt AppImage tested manually with a `Default` registry name and `luca` display name
