### PR TITLE
feat: detect Linux agent CLIs installed in user-scoped dirs (nvm/bun/npm-prefix/pnpm)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ### Added
 
+- Agent CLIs installed via nvm, bun, `npm --prefix`, pnpm or volta are now detected on Linux
+  even when Alethe is launched from the desktop menu — which inherits a minimal PATH — matching
+  the existing `~/.local/bin` and `~/.cargo/bin` fallbacks. Onboarding and agent tabs now see
+  these installs instead of reporting them as missing.
 - When an agent opens a page in the shared browser, Alethe asks where it should go. The browser
   itself has no window, which is right most of the time — an agent reading a page needs no
   interface at all — so the question only comes up when a page actually appears. All three

--- a/src-tauri/src/cli_resolver.rs
+++ b/src-tauri/src/cli_resolver.rs
@@ -178,6 +178,10 @@ fn resolve_cli_launcher(command: &str) -> Option<PathBuf> {
         // mesmo estando no disco. Cobrir os prefixos padrão do Homebrew
         // (Apple Silicon e Intel) como fallback fixo.
         dirs.extend(homebrew_dirs());
+        // Linux user-scoped installers (nvm, bun, npm --prefix, pnpm, volta) —
+        // invisible under the minimal PATH a desktop menu inherits.
+        #[cfg(target_os = "linux")]
+        dirs.extend(linux_user_bin_dirs());
         for dir in dirs {
             let candidate = dir.join(command);
             if candidate.is_file() {
@@ -313,6 +317,56 @@ fn homebrew_dirs() -> Vec<PathBuf> {
         PathBuf::from("/usr/local/bin"),
         PathBuf::from("/usr/local/sbin"),
     ]
+}
+
+/// Standard user bin dirs for Linux package managers. Desktop menus launch the
+/// app with a minimal PATH, so agents installed via `npm --prefix`, bun, pnpm,
+/// volta or nvm are invisible to `which`; these are the default install roots
+/// for each tool (mirrors `agent_search_dirs` on Windows and the fixed Homebrew
+/// fallback on macOS).
+#[cfg(target_os = "linux")]
+fn linux_user_bin_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::<PathBuf>::new();
+    if let Some(home) = env::var_os("HOME").map(PathBuf::from) {
+        dirs.push(home.join(".npm-global").join("bin"));
+        dirs.push(home.join(".bun").join("bin"));
+        dirs.push(home.join(".volta").join("bin"));
+        dirs.push(home.join(".local").join("share").join("pnpm"));
+    }
+    if let Some(pnpm_home) = env::var_os("PNPM_HOME").map(PathBuf::from) {
+        dirs.push(pnpm_home);
+    }
+    // nvm installs one versioned bin dir per node release; pick every one
+    // newest first (same pattern as `fnm_version_dirs`).
+    let nvm_root = env::var_os("NVM_DIR")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|h| PathBuf::from(h).join(".nvm")));
+    if let Some(root) = nvm_root {
+        let versions_dir = root.join("versions").join("node");
+        if let Ok(entries) = fs::read_dir(&versions_dir) {
+            let mut versions: Vec<(PathBuf, SystemTime)> = entries
+                .filter_map(|entry| entry.ok())
+                .filter_map(|entry| {
+                    let path = entry.path();
+                    let name = path.file_name()?.to_str()?.to_string();
+                    if !name.starts_with('v') {
+                        return None;
+                    }
+                    let bin = path.join("bin");
+                    if !bin.is_dir() {
+                        return None;
+                    }
+                    let modified = entry.metadata().and_then(|m| m.modified()).ok()?;
+                    Some((bin, modified))
+                })
+                .collect();
+            versions.sort_by(|a, b| b.1.cmp(&a.1));
+            for (bin, _) in versions {
+                dirs.push(bin);
+            }
+        }
+    }
+    dirs
 }
 
 /// Looks for the VS Code launcher (`code`) in common locations plus PATH.
@@ -939,5 +993,41 @@ mod tests {
     fn resolves_cli_launcher_on_unix() {
         assert!(find_windows_cli_launcher("sh").is_some());
         assert!(find_windows_cli_launcher("non_existent_binary_xyz_123").is_none());
+    }
+
+    /// With the Linux user-bin-dirs fallback, an agent installed via
+    /// `npm --prefix ~/.npm-global` is found even under a minimal desktop-menu
+    /// PATH.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_user_bin_dirs_finds_npm_global_agents() {
+        let home = std::env::temp_dir().join("alethe-audit-home");
+        let npm_global = home.join(".npm-global").join("bin");
+        std::fs::create_dir_all(&npm_global).expect("create npm-global dir");
+        std::fs::write(npm_global.join("fake-agent-audit"), "#!/bin/sh\necho hi\n")
+            .expect("write fake agent");
+        let original_home = std::env::var_os("HOME");
+        let original_path = std::env::var_os("PATH");
+        std::env::set_var("HOME", &home);
+        std::env::set_var(
+            "PATH",
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        );
+        let found = find_windows_cli_launcher("fake-agent-audit");
+        assert!(
+            found.is_some(),
+            "linux_user_bin_dirs should find npm-global installs: {found:?}"
+        );
+        if let Some(h) = original_home {
+            std::env::set_var("HOME", h);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(p) = original_path {
+            std::env::set_var("PATH", p);
+        } else {
+            std::env::remove_var("PATH");
+        }
+        let _ = std::fs::remove_dir_all(&home);
     }
 }


### PR DESCRIPTION
Fixes #157

## Problem
On Linux, desktop-menu launches inherit a minimal PATH (`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`), so agent CLIs installed via **nvm**, **bun**, **`npm --prefix`**, **pnpm** or **volta** were invisible to the resolver — only `~/.local/bin` and `~/.cargo/bin` were covered by the fallback. Onboarding showed these agents as unavailable and spawned terminals failed with `command not found`.

## Change
- `src-tauri/src/cli_resolver.rs`: new `#[cfg(target_os = "linux")] linux_user_bin_dirs()` covering `~/.npm-global/bin`, `~/.bun/bin`, `~/.volta/bin`, `~/.local/share/pnpm`, `$PNPM_HOME`, and `$NVM_DIR/versions/node/*/bin` (newest first, same enumeration pattern as `fnm_version_dirs`), extended in the non-Windows fallback of `resolve_cli_launcher` — mirroring the macOS Homebrew fallback (PR #96) and the Windows `agent_search_dirs`.
- Unit test: an agent under `~/.npm-global/bin` is found with a minimal menu PATH.
- `docs/CHANGELOG.md`: entry under `[Unreleased]`.

## Verification (Linux, real compiled backend)
- `cargo test --lib cli_resolver` → 4/4 passed (incl. the new test).
- Additive and Linux-gated; no new dependencies.

## Note on CI
`cargo test` still shows the **pre-existing** failure `pty::tests::a_kill_never_runs_while_the_child_lock_is_held` (issue #155, PR #156). This branch does **not** touch `pty.rs`; that failure is unrelated and will disappear when #156 merges.