### PR TITLE
fix(mcp): serialize opencode.json writes to prevent race conditions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -195,6 +195,9 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 - The **Continue in Claude Code** button in the agent handoff dialog was unreadable. It painted its
   label with a colour token that does not exist anywhere in the app, so the text fell back to the
   inherited foreground and sat light-on-accent.
+- Multiple features (Graphify, GSD plugin, AI Memory) now share a lock when writing to
+  `opencode.json`, preventing race conditions where concurrent read-modify-write cycles
+  clobbered each other's MCP entries.
 
 ## [1.6.0] — 2026-08-17
 

--- a/src-tauri/src/ai_memory.rs
+++ b/src-tauri/src/ai_memory.rs
@@ -109,6 +109,9 @@ pub fn ai_memory_opencode_config_write(
     repo: String,
     command: Option<String>,
 ) -> Result<(), String> {
+    let _guard = crate::provider_common::opencode_json_lock()
+        .lock()
+        .map_err(|_| "opencode.json lock poisoned".to_string())?;
     let root = repository_root(&repo)?;
     let cmd = command.unwrap_or_else(|| DEFAULT_COMMAND.to_string());
     let path = root.join("opencode.json");

--- a/src-tauri/src/graphify.rs
+++ b/src-tauri/src/graphify.rs
@@ -267,6 +267,9 @@ pub(crate) fn graphify_opencode_config_write_inner(
     repo: String,
     command: Option<String>,
 ) -> Result<(), String> {
+    let _guard = crate::provider_common::opencode_json_lock()
+        .lock()
+        .map_err(|_| "opencode.json lock poisoned".to_string())?;
     let root = repository_root(&repo)?;
     let cmd = command.unwrap_or_else(|| DEFAULT_COMMAND.to_string());
     let path = root.join("opencode.json");

--- a/src-tauri/src/opencode_gsd_plugin.rs
+++ b/src-tauri/src/opencode_gsd_plugin.rs
@@ -78,6 +78,9 @@ fn write_gsd_config_sidecar(root: &std::path::Path, model_chain: &[String]) -> R
 }
 
 fn write_opencode_plugin_entry(root: &std::path::Path) -> Result<(), String> {
+    let _guard = crate::provider_common::opencode_json_lock()
+        .lock()
+        .map_err(|_| "opencode.json lock poisoned".to_string())?;
     let path = root.join("opencode.json");
 
     let mut config: serde_json::Map<String, Value> = if path.is_file() {

--- a/src-tauri/src/provider_common.rs
+++ b/src-tauri/src/provider_common.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Resolve `~/<segments>` a partir de `USERPROFILE` (Windows) ou `HOME` (Unix).
@@ -35,6 +36,14 @@ pub(crate) fn normalize_cwd(cwd: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+/// Serializes all read-modify-write cycles on `opencode.json`. Multiple writers
+/// (Graphify, GSD plugin, AI Memory) race to insert their MCP entry into the
+/// same file; without a lock the last writer clobbers the others.
+pub(crate) fn opencode_json_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Multiple features (Graphify, GSD plugin, AI Memory) write to `opencode.json` using read-modify-write cycles. Without synchronization, concurrent writes clobbered each other's MCP entries.

This adds a shared `Mutex<()>` in `provider_common` that serializes all `opencode.json` mutations. The lock is acquired before reading the file and held through the write, ensuring atomicity across all three writers.

Files changed:
- `provider_common.rs` — add `opencode_json_lock()`
- `graphify.rs` — acquire lock in `graphify_opencode_config_write_inner`
- `ai_memory.rs` — acquire lock in `ai_memory_opencode_config_write`
- `opencode_gsd_plugin.rs` — acquire lock in `write_opencode_plugin_entry`

Also updates CHANGELOG.md under [Unreleased] > Fixed.