### PR TITLE
fix(build): set default-run so tauri dev can pick the app binary

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,10 @@ description = "Alethe — terminal multiplexer GUI"
 authors = ["Kauã Miguel"]
 license = "AGPL-3.0-or-later"
 edition = "2021"
+# Two binaries in this crate (alethe + alethe-orchestrator-mcp). Without
+# default-run, the bare `cargo run` that `tauri dev` issues cannot pick one and
+# aborts before the app ever starts.
+default-run = "alethe"
 
 [lib]
 name = "alethe_lib"


### PR DESCRIPTION
O `npm run app` falha na hora num clone novo. O `tauri dev` dispara um `cargo run` puro e, desde que o `src/bin/alethe-orchestrator-mcp.rs` foi adicionado no `00cf323`, o crate tem duas binaries sem `default-run` — então o cargo aborta:

```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: alethe, alethe-orchestrator-mcp
```

O CI não pega isso: o `ci.yml` roda `npm run build` e `cargo test`, e a ambiguidade só existe no `cargo run`. Os bundles de release não são afetados — o que quebra é só o caminho de rodar a partir do código-fonte, documentado no README.

Testado no Windows 11: com a correção, o `npm run app` compila e abre o app.
