### PR TITLE
feat: place window controls by desktop layout on Linux

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,11 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ### Added
 
+- Window minimize / maximize / close follow the desktop layout on Linux: Alethe reads GNOME's
+  `button-layout` (so Pop!_OS / Ubuntu left-hand chrome is mirrored) and places the buttons on
+  that side in the matching order. Preferences → Appearance can still force left, right, or
+  System. Windows stays right-hand; macOS uses traffic-light order on the left.
+
 - Agent orchestration, off by default under a new preference. When it is on, Claude Code terminals
   get a set of Alethe tools for handing independent units of work to Codex workers that Alethe runs
   in parallel, up to a concurrency limit it enforces itself. The lead gets job ids back immediately

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,7 @@ mod stats;
 mod supervisor;
 mod telemetry;
 mod validation;
+mod window_controls;
 mod window_style;
 #[cfg(windows)]
 mod windows_webview;
@@ -397,6 +398,7 @@ pub fn run() {
             crash_watch::get_last_crash_report,
             crash_watch::get_job_guard_status,
             set_window_opacity,
+            window_controls::desktop_window_controls,
             quit_app,
             worktrees::worktree_provision,
             worktrees::worktree_list,

--- a/src-tauri/src/window_controls.rs
+++ b/src-tauri/src/window_controls.rs
@@ -1,0 +1,206 @@
+//! Desktop window-control layout (minimize / maximize / close).
+//!
+//! On Linux/GNOME, `org.gnome.desktop.wm.preferences button-layout` decides which
+//! side the buttons sit on (e.g. Pop!_OS / Ubuntu often use the left). Windows
+//! keeps the classic right-hand order; macOS mirrors traffic-light order on the left.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WindowControlSide {
+    Left,
+    Right,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WindowControlButton {
+    Close,
+    Minimize,
+    Maximize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowControlsLayout {
+    pub side: WindowControlSide,
+    pub buttons: Vec<WindowControlButton>,
+    /// Where the layout came from: `gnome`, `macos`, `windows`, or `linux-default`.
+    pub source: String,
+}
+
+fn default_windows() -> WindowControlsLayout {
+    WindowControlsLayout {
+        side: WindowControlSide::Right,
+        buttons: vec![
+            WindowControlButton::Minimize,
+            WindowControlButton::Maximize,
+            WindowControlButton::Close,
+        ],
+        source: "windows".into(),
+    }
+}
+
+fn default_macos() -> WindowControlsLayout {
+    WindowControlsLayout {
+        side: WindowControlSide::Left,
+        buttons: vec![
+            WindowControlButton::Close,
+            WindowControlButton::Minimize,
+            WindowControlButton::Maximize,
+        ],
+        source: "macos".into(),
+    }
+}
+
+fn default_linux() -> WindowControlsLayout {
+    // Ubuntu/Pop-style default when gsettings is unavailable.
+    WindowControlsLayout {
+        side: WindowControlSide::Left,
+        buttons: vec![
+            WindowControlButton::Close,
+            WindowControlButton::Minimize,
+            WindowControlButton::Maximize,
+        ],
+        source: "linux-default".into(),
+    }
+}
+
+fn parse_button(token: &str) -> Option<WindowControlButton> {
+    match token.trim().to_ascii_lowercase().as_str() {
+        "close" => Some(WindowControlButton::Close),
+        "minimize" | "min" => Some(WindowControlButton::Minimize),
+        "maximize" | "max" => Some(WindowControlButton::Maximize),
+        _ => None,
+    }
+}
+
+fn parse_side(tokens: &str) -> Vec<WindowControlButton> {
+    tokens
+        .split(',')
+        .filter_map(parse_button)
+        .collect::<Vec<_>>()
+}
+
+/// Parse GNOME `button-layout` values such as `close,minimize,maximize:appmenu`.
+pub fn parse_gnome_button_layout(raw: &str) -> Option<WindowControlsLayout> {
+    let trimmed = raw.trim().trim_matches('\'').trim_matches('"').trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let (left_raw, right_raw) = match trimmed.split_once(':') {
+        Some((left, right)) => (left, right),
+        None => (trimmed, ""),
+    };
+
+    let left = parse_side(left_raw);
+    let right = parse_side(right_raw);
+
+    let (side, buttons) = if !left.is_empty() {
+        (WindowControlSide::Left, left)
+    } else if !right.is_empty() {
+        (WindowControlSide::Right, right)
+    } else {
+        return None;
+    };
+
+    Some(WindowControlsLayout {
+        side,
+        buttons,
+        source: "gnome".into(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_gnome_button_layout() -> Option<WindowControlsLayout> {
+    let output = std::process::Command::new("gsettings")
+        .args([
+            "get",
+            "org.gnome.desktop.wm.preferences",
+            "button-layout",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    parse_gnome_button_layout(&raw)
+}
+
+#[tauri::command]
+pub fn desktop_window_controls() -> WindowControlsLayout {
+    #[cfg(target_os = "windows")]
+    {
+        return default_windows();
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return default_macos();
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(layout) = read_gnome_button_layout() {
+            return layout;
+        }
+        return default_linux();
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        default_windows()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pop_os_left_layout() {
+        let layout = parse_gnome_button_layout("'close,minimize,maximize:appmenu'").unwrap();
+        assert_eq!(layout.side, WindowControlSide::Left);
+        assert_eq!(
+            layout.buttons,
+            vec![
+                WindowControlButton::Close,
+                WindowControlButton::Minimize,
+                WindowControlButton::Maximize,
+            ]
+        );
+        assert_eq!(layout.source, "gnome");
+    }
+
+    #[test]
+    fn parses_windows_like_right_layout() {
+        let layout = parse_gnome_button_layout("appmenu:minimize,maximize,close").unwrap();
+        assert_eq!(layout.side, WindowControlSide::Right);
+        assert_eq!(
+            layout.buttons,
+            vec![
+                WindowControlButton::Minimize,
+                WindowControlButton::Maximize,
+                WindowControlButton::Close,
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_unknown_tokens() {
+        let layout = parse_gnome_button_layout("spacer,close,appmenu:").unwrap();
+        assert_eq!(layout.side, WindowControlSide::Left);
+        assert_eq!(layout.buttons, vec![WindowControlButton::Close]);
+    }
+
+    #[test]
+    fn empty_or_junk_returns_none() {
+        assert!(parse_gnome_button_layout("").is_none());
+        assert!(parse_gnome_button_layout("appmenu:spacer").is_none());
+    }
+}

--- a/src/components/TitleBar/TitleBar.module.css
+++ b/src/components/TitleBar/TitleBar.module.css
@@ -600,20 +600,37 @@
   cursor: pointer;
 }
 
-.barEnd > .widgets + .windowBtn,
-.barEnd > .rightSidebarBtn + .windowBtn {
+.windowControls {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  flex-shrink: 0;
+}
+
+.windowControls[data-side='right'] {
   margin-left: 4px;
   border-left: 1px solid var(--border);
-  padding-left: 6px;
-  width: 34px;
+  padding-left: 2px;
 }
+
+.windowControls[data-side='left'] {
+  margin-right: 4px;
+  border-right: 1px solid var(--border);
+  padding-right: 2px;
+}
+
+.barEnd > .widgets + .windowControls,
+.barEnd > .rightSidebarBtn + .windowControls {
+  margin-left: 4px;
+}
+
 .windowBtn:hover {
   background: var(--panel-hover);
   color: var(--fg);
 }
 .close:hover {
-  background: #e81123;
-  color: #fff;
+  background: var(--status-offline);
+  color: var(--bg);
 }
 
 .bar[data-style='three-areas'] .barStart {

--- a/src/components/TitleBar/index.tsx
+++ b/src/components/TitleBar/index.tsx
@@ -18,7 +18,7 @@ import {
   Workflow,
   X,
 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 
 import { ContextMenu, type MenuItem } from '../ProjectSidebar/ContextMenu'
 import { AntigravityIcon, ClaudeIcon, CodexIcon } from '../icons/AgentIcons'
@@ -29,8 +29,10 @@ import { getCachedAntigravityUsage } from '../../lib/antigravityUsageCache'
 import { requestAppClose } from '../../hooks/useCloseConfirmation'
 import { observeClaudeReset, observeCodexReset } from '../../lib/limitResetWatch'
 import { useT } from '../../lib/i18n'
-import { formatShortcut } from '../../lib/platform'
-import { killPty, remoteControlConnectedDevices } from '../../lib/tauri'
+import { formatShortcut, isMacOS, isWindows } from '../../lib/platform'
+import { desktopWindowControls, killPty, remoteControlConnectedDevices } from '../../lib/tauri'
+import type { WindowControlButton, WindowControlsLayout } from '../../lib/tauri'
+import { resolveWindowControlsLayout } from '../../lib/windowControls'
 import { useProjectsStore } from '../../stores/projectsStore'
 import { useUiStore } from '../../stores/uiStore'
 import styles from './TitleBar.module.css'
@@ -90,6 +92,66 @@ function MemoryPillButton({ ramMb }: { ramMb: number }) {
   )
 }
 
+function WindowControls({
+  layout,
+  onMinimize,
+  onMaximize,
+  onClose,
+}: {
+  layout: WindowControlsLayout
+  onMinimize: () => void
+  onMaximize: () => void
+  onClose: () => void
+}) {
+  const t = useT()
+  const actions: Record<
+    WindowControlButton,
+    { onClick: () => void; title: string; className?: string; icon: ReactNode }
+  > = {
+    minimize: {
+      onClick: onMinimize,
+      title: t('ui.titlebar.minimize'),
+      icon: <Minus size={14} />,
+    },
+    maximize: {
+      onClick: onMaximize,
+      title: t('ui.titlebar.maximize'),
+      icon: <Maximize2 size={12} />,
+    },
+    close: {
+      onClick: onClose,
+      title: t('ui.titlebar.close'),
+      className: styles.close,
+      icon: <X size={14} />,
+    },
+  }
+
+  return (
+    <div
+      className={styles.windowControls}
+      data-side={layout.side}
+      role="group"
+      aria-label={t('ui.titlebar.windowControls')}
+    >
+      {layout.buttons.map((button) => {
+        const action = actions[button]
+        return (
+          <button
+            key={button}
+            type="button"
+            className={`${styles.windowBtn} ${action.className ?? ''}`}
+            onClick={action.onClick}
+            title={action.title}
+            aria-label={action.title}
+          >
+            {action.icon}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 export function TitleBar() {
   const t = useT()
   const toggleMainMenu = useUiStore((s) => s.toggleMainMenu)
@@ -125,8 +187,25 @@ export function TitleBar() {
   const navigateWorkspaceHistory = useProjectsStore((s) => s.navigateWorkspaceHistory)
   const [tabMenu, setTabMenu] = useState<{ x: number; y: number; items: MenuItem[] } | null>(null)
   const [remoteConnectedDevices, setRemoteConnectedDevices] = useState(0)
+  const [detectedWindowControls, setDetectedWindowControls] = useState<WindowControlsLayout | null>(
+    () => {
+      // Optimistic placement before the desktop query returns — avoids a right→left flash on Linux/GNOME.
+      if (isWindows()) {
+        return { side: 'right', buttons: ['minimize', 'maximize', 'close'], source: 'pending' }
+      }
+      if (isMacOS()) {
+        return { side: 'left', buttons: ['close', 'minimize', 'maximize'], source: 'pending' }
+      }
+      return { side: 'left', buttons: ['close', 'minimize', 'maximize'], source: 'pending' }
+    },
+  )
   const activeProfile = profiles.find((profile) => profile.id === activeProfileId) ?? null
   const threeAreas = preferences.topbarStyle === 'three-areas'
+  const windowControls = resolveWindowControlsLayout(
+    detectedWindowControls,
+    preferences.windowControlsPlacement,
+  )
+  const windowControlsOnLeft = windowControls.side === 'left'
   const antigravityReady =
     antigravityUsage?.status === 'ready' && antigravityUsage.buckets.length > 0
   const remoteConnectedLabel = t(
@@ -298,10 +377,34 @@ export function TitleBar() {
     void win.setTitle(APP_TITLE)
   }, [win])
 
+  useEffect(() => {
+    let cancelled = false
+    void desktopWindowControls()
+      .then((layout) => {
+        if (!cancelled) setDetectedWindowControls(layout)
+      })
+      .catch(() => {
+        // Keep the optimistic OS default already in state.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const windowControlsEl = (
+    <WindowControls
+      layout={windowControls}
+      onMinimize={() => void win.minimize()}
+      onMaximize={() => void win.toggleMaximize()}
+      onClose={() => void requestAppClose()}
+    />
+  )
+
   return (
     <div
       className={styles.bar}
       data-style={preferences.topbarStyle}
+      data-window-controls={windowControls.side}
       data-tauri-drag-region
       style={
         {
@@ -315,6 +418,7 @@ export function TitleBar() {
       }
     >
       <div className={styles.barStart}>
+        {windowControlsOnLeft ? windowControlsEl : null}
         <button
           type="button"
           className={styles.iconBtn}
@@ -755,33 +859,7 @@ export function TitleBar() {
             )}
           </button>
         ) : null}
-        <button
-          type="button"
-          className={styles.windowBtn}
-          onClick={() => void win.minimize()}
-          title={t('ui.titlebar.minimize')}
-          aria-label={t('ui.titlebar.minimize')}
-        >
-          <Minus size={14} />
-        </button>
-        <button
-          type="button"
-          className={styles.windowBtn}
-          onClick={() => void win.toggleMaximize()}
-          title={t('ui.titlebar.maximize')}
-          aria-label={t('ui.titlebar.maximize')}
-        >
-          <Maximize2 size={12} />
-        </button>
-        <button
-          type="button"
-          className={`${styles.windowBtn} ${styles.close}`}
-          onClick={() => void requestAppClose()}
-          title={t('ui.titlebar.close')}
-          aria-label={t('ui.titlebar.close')}
-        >
-          <X size={14} />
-        </button>
+        {windowControlsOnLeft ? null : windowControlsEl}
       </div>
       {tabMenu ? (
         <ContextMenu

--- a/src/components/modals/preferences/AppearancePage.test.tsx
+++ b/src/components/modals/preferences/AppearancePage.test.tsx
@@ -14,6 +14,7 @@ const store = vi.hoisted(() => ({
       uiTheme: 'dark',
       uiZoom: 1,
       visualStyle: 'normal',
+      windowControlsPlacement: 'system',
       windowOpacity: 1,
     },
     setPreferences: vi.fn(),

--- a/src/components/modals/preferences/AppearancePage.tsx
+++ b/src/components/modals/preferences/AppearancePage.tsx
@@ -255,6 +255,27 @@ export function AppearancePage() {
       </SettingsSection>
 
       <SettingsSection
+        id="window-controls-placement"
+        title={t('prefs.windowControlsPlacement')}
+        description={t('prefs.windowControlsPlacementDesc')}
+      >
+        <Dropdown
+          value={preferences.windowControlsPlacement}
+          onChange={(value) =>
+            setPreferences({
+              windowControlsPlacement: value as 'system' | 'left' | 'right',
+            })
+          }
+          ariaLabel={t('prefs.windowControlsPlacement')}
+          options={[
+            { value: 'system', label: t('prefs.windowControlsPlacementSystem') },
+            { value: 'left', label: t('prefs.windowControlsPlacementLeft') },
+            { value: 'right', label: t('prefs.windowControlsPlacementRight') },
+          ]}
+        />
+      </SettingsSection>
+
+      <SettingsSection
         id="git-control-placement"
         title={t('prefs.gitControlPlacement')}
         description={t('prefs.gitControlPlacementDesc')}

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -493,6 +493,12 @@ export const en = {
     'Choose how the topbar divides sidebars, tabs, status, and window controls.',
   'prefs.topbarStyleClassic': 'Classic',
   'prefs.topbarStyleThreeAreas': 'Three areas',
+  'prefs.windowControlsPlacement': 'Window controls',
+  'prefs.windowControlsPlacementDesc':
+    'Where minimize, maximize and close sit in the title bar. System follows the desktop (GNOME button-layout on Linux).',
+  'prefs.windowControlsPlacementSystem': 'System',
+  'prefs.windowControlsPlacementLeft': 'Left',
+  'prefs.windowControlsPlacementRight': 'Right',
   'prefs.gitControl': 'Git Control sidebar',
   'prefs.gitControlDesc': 'Show or hide the Source Control tab in the project sidebar.',
   'prefs.gitControlShow': 'Show',
@@ -1334,6 +1340,7 @@ export const en = {
   'ui.titlebar.minimize': 'Minimize',
   'ui.titlebar.maximize': 'Maximize',
   'ui.titlebar.close': 'Close',
+  'ui.titlebar.windowControls': 'Window controls',
   'appClose.title': 'Close Alethe?',
   'appClose.message':
     'Open agents and terminals will be stopped. Saved conversations can be resumed the next time you open Alethe.',

--- a/src/lib/i18n/messages/pt-BR.ts
+++ b/src/lib/i18n/messages/pt-BR.ts
@@ -498,6 +498,12 @@ export const ptBR: Record<MessageKey, string> = {
     'Escolha como a topbar divide sidebars, abas, status e controles da janela.',
   'prefs.topbarStyleClassic': 'Clássico',
   'prefs.topbarStyleThreeAreas': 'Três áreas',
+  'prefs.windowControlsPlacement': 'Controles da janela',
+  'prefs.windowControlsPlacementDesc':
+    'Onde ficam minimizar, maximizar e fechar na barra de título. Sistema segue o desktop (button-layout do GNOME no Linux).',
+  'prefs.windowControlsPlacementSystem': 'Sistema',
+  'prefs.windowControlsPlacementLeft': 'Esquerda',
+  'prefs.windowControlsPlacementRight': 'Direita',
   'prefs.gitControl': 'Controle Git na sidebar',
   'prefs.gitControlDesc': 'Mostre ou oculte a aba Source Control na sidebar de projetos.',
   'prefs.gitControlShow': 'Mostrar',
@@ -1352,6 +1358,7 @@ export const ptBR: Record<MessageKey, string> = {
   'ui.titlebar.minimize': 'Minimizar',
   'ui.titlebar.maximize': 'Maximizar',
   'ui.titlebar.close': 'Fechar',
+  'ui.titlebar.windowControls': 'Controles da janela',
   'appClose.title': 'Fechar o Alethe?',
   'appClose.message':
     'Agentes e terminais abertos serão encerrados. As conversas salvas poderão ser retomadas quando você abrir o Alethe novamente.',

--- a/src/lib/tauri/window.ts
+++ b/src/lib/tauri/window.ts
@@ -1,6 +1,21 @@
 import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 
+export type WindowControlSide = 'left' | 'right'
+export type WindowControlButton = 'close' | 'minimize' | 'maximize'
+
+export type WindowControlsLayout = {
+  side: WindowControlSide
+  buttons: WindowControlButton[]
+  /** `gnome` | `macos` | `windows` | `linux-default` */
+  source: string
+}
+
+/** Desktop-native window chrome placement (GNOME button-layout on Linux). */
+export async function desktopWindowControls(): Promise<WindowControlsLayout> {
+  return invoke<WindowControlsLayout>('desktop_window_controls')
+}
+
 export async function setWindowOpacity(opacity: number): Promise<void> {
   await invoke('set_window_opacity', { opacity })
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -448,6 +448,11 @@ export type Preferences = {
   lastTerminalCreation: TerminalCreationPreset | null
 
   topbarStyle: 'classic' | 'three-areas'
+  /**
+   * Where minimize / maximize / close sit in the custom title bar.
+   * `system` follows the OS (GNOME `button-layout` on Linux); left/right force a side.
+   */
+  windowControlsPlacement: 'system' | 'left' | 'right'
   /** Local do controle Git: sidebar esquerda ou direita. */
   gitControlPlacement: 'left' | 'right'
 
@@ -584,6 +589,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   alwaysStartUnrestricted: false,
   lastTerminalCreation: null,
   topbarStyle: 'classic',
+  windowControlsPlacement: 'system',
   gitControlPlacement: 'left',
   spotifyClientId: '',
   spotifyClientSecret: '',

--- a/src/lib/windowControls.test.ts
+++ b/src/lib/windowControls.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveWindowControlsLayout } from './windowControls'
+
+describe('resolveWindowControlsLayout', () => {
+  const gnomeLeft = {
+    side: 'left' as const,
+    buttons: ['close', 'minimize', 'maximize'] as const,
+    source: 'gnome',
+  }
+
+  it('keeps the detected GNOME left layout when preference is system', () => {
+    expect(resolveWindowControlsLayout({ ...gnomeLeft, buttons: [...gnomeLeft.buttons] }, 'system')).toEqual(
+      {
+        side: 'left',
+        buttons: ['close', 'minimize', 'maximize'],
+        source: 'gnome',
+      },
+    )
+  })
+
+  it('forces right-hand Windows-like order when preference is right', () => {
+    expect(resolveWindowControlsLayout({ ...gnomeLeft, buttons: [...gnomeLeft.buttons] }, 'right')).toEqual(
+      {
+        side: 'right',
+        buttons: ['minimize', 'maximize', 'close'],
+        source: 'gnome',
+      },
+    )
+  })
+
+  it('falls back to right when detection is missing', () => {
+    expect(resolveWindowControlsLayout(null, 'system').side).toBe('right')
+  })
+})

--- a/src/lib/windowControls.ts
+++ b/src/lib/windowControls.ts
@@ -1,0 +1,38 @@
+import type { WindowControlButton, WindowControlsLayout, WindowControlSide } from './tauri'
+
+export type WindowControlsPlacementPreference = 'system' | 'left' | 'right'
+
+const FALLBACK_RIGHT: WindowControlsLayout = {
+  side: 'right',
+  buttons: ['minimize', 'maximize', 'close'],
+  source: 'fallback',
+}
+
+const FALLBACK_LEFT: WindowControlsLayout = {
+  side: 'left',
+  buttons: ['close', 'minimize', 'maximize'],
+  source: 'fallback',
+}
+
+/** Apply a user preference on top of the desktop-detected layout. */
+export function resolveWindowControlsLayout(
+  detected: WindowControlsLayout | null | undefined,
+  preference: WindowControlsPlacementPreference = 'system',
+): WindowControlsLayout {
+  const base = detected ?? FALLBACK_RIGHT
+  if (preference === 'system') return base
+  if (preference === base.side) return base
+  return {
+    side: preference,
+    buttons: preference === 'left' ? FALLBACK_LEFT.buttons : FALLBACK_RIGHT.buttons,
+    source: base.source,
+  }
+}
+
+export function isWindowControlButton(value: string): value is WindowControlButton {
+  return value === 'close' || value === 'minimize' || value === 'maximize'
+}
+
+export function isWindowControlSide(value: string): value is WindowControlSide {
+  return value === 'left' || value === 'right'
+}

--- a/src/stores/projectsStore.migrations.ts
+++ b/src/stores/projectsStore.migrations.ts
@@ -108,6 +108,11 @@ export function normalizePreferences(raw: LegacyPreferences | undefined): Prefer
     motionPreference: raw?.motionPreference === 'reduced' ? 'reduced' : 'animated',
     accountCreated: legacyAccountCreated,
     topbarStyle: preferences.topbarStyle === 'three-areas' ? 'three-areas' : 'classic',
+    windowControlsPlacement:
+      preferences.windowControlsPlacement === 'left' ||
+      preferences.windowControlsPlacement === 'right'
+        ? preferences.windowControlsPlacement
+        : 'system',
     gitControlPlacement: preferences.gitControlPlacement === 'right' ? 'right' : 'left',
     mcpDefaultScope: preferences.mcpDefaultScope === 'project' ? 'project' : 'global',
     mcpOnboardingSeen: Boolean(preferences.mcpOnboardingSeen),


### PR DESCRIPTION
## Summary
- On Linux, minimize / maximize / close follow the desktop chrome: Alethe reads GNOME `button-layout` (e.g. Pop!_OS / Ubuntu left-hand controls) and places the buttons on that side in matching order.
- Preferences → Appearance adds Window controls (System / Left / Right); Windows stays right-hand and macOS keeps traffic-light order on the left.
- Includes Tauri `desktop_window_controls` command, title-bar layout/CSS updates, preference migration, i18n (EN + pt-BR), changelog, and unit tests for layout resolution.

## Test plan
- [ ] On Linux/GNOME with left-hand button-layout, confirm controls appear on the left in desktop order without a right→left flash on startup
- [ ] Change Preferences → Appearance → Window controls between System / Left / Right and verify title bar updates
- [ ] On Windows, confirm controls stay on the right; on macOS, traffic-light order on the left
- [ ] Run `npm test` (windowControls + AppearancePage) and smoke the title bar minimize / maximize / close actions


Made with [Cursor](https://cursor.com)