### PR TITLE
fix(linux): remove wayland libs do appimage pra resolver crash no arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
           # `npm run tauri signer generate` e cadastre nos secrets do repo.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Evita empacotar as bibliotecas do Wayland para não dar conflito com as do host.
+          # Isso previne o crash EGL_BAD_PARAMETER no WebKit ao abrir no Arch e Fedora.
+          LINUXDEPLOY_PLUGIN_GTK_OMIT_LIBRARIES: "libwayland-client.so.1:libwayland-egl.so.1"
         with:
           tagName: v__VERSION__
           releaseName: 'Alethe v__VERSION__'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -132,6 +132,10 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ### Fixed
 
+- AppImage no longer crashes on Arch Linux and other non-Ubuntu distributions with AMD/NVIDIA GPUs
+  under Wayland (`EGL_BAD_PARAMETER` on startup). The Wayland client libraries bundled by
+  `linuxdeploy` conflicted with the host system's versions; the build now tells the bundler to
+  leave them out and let the OS supply them.
 - The Source Control panel in the right sidebar no longer stays empty for a selected project that
   has no open terminal — it now falls back to the project's default working directory.
 - The ephemeral conflict-resolution agent's initial prompt is now delivered reliably to OpenCode.


### PR DESCRIPTION
## What changed

Resolvendo o crash no Arch Linux com Wayland (`EGL_BAD_PARAMETER`).

O `linuxdeploy-plugin-gtk` estava empacotando as libs `libwayland-client.so.1` e `libwayland-egl.so.1` do Ubuntu direto no AppImage. Quando tenta abrir no Arch com AMD (ou NVIDIA), o WebKit puxa essas libs embutidas em vez das nativas do sistema e quebra antes mesmo de renderizar a janela.

Pra arrumar, foi só adicionar o `LINUXDEPLOY_PLUGIN_GTK_OMIT_LIBRARIES` no `release.yml` ignorando essas libs. Como toda distro Wayland já tem isso nativo, não vai quebrar nada no Ubuntu e resolve o crash geral para outras distribuições Linux modernas. 

Aviso: como o crash só acontece por conta do ambiente de build do Ubuntu (Actions), essa correção pode ser testada rodando o workflow de release e validando o `.appimage` final gerado.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor / chore

## Tested on

- [ ] Windows
- [ ] macOS
- [x] Linux

## Checklist

- [x] `npm run build` passes (typecheck + build)
- [x] `npm test` passes
- [x] `npm run format` was run
- [ ] User-facing strings go through `t()` and exist in both `en.ts` and `pt-BR.ts`
- [ ] Colors/spacing use tokens from `styles/theme.css` — no hardcoded values
- [x] `docs/CHANGELOG.md` updated under `[Não lançado]` (features only)