### PR TITLE
fix(agents): confirm a CLI install without waiting for the installer's shell

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,15 @@ Notable user-facing changes to **Alethe** are documented here. The format is bas
 
 ## [Unreleased]
 
+### Fixed
+
+- Installing a CLI from inside Alethe no longer ends in a dialog that spins forever. The install
+  screen now watches for the CLI itself while the installer runs, instead of waiting only for the
+  installer's shell to exit — some of them hand the prompt back or leave a progress bar behind and
+  never exit — so the dialog closes on its own as soon as the CLI is really there. Detection also
+  re-reads the machine's environment on every check, so a CLI that adds itself to PATH is found
+  without restarting the app.
+
 ### Added
 
 - Pull Request review and squash merge from the merge panel. Alethe locates an open GitHub Pull

--- a/src-tauri/src/cli_resolver.rs
+++ b/src-tauri/src/cli_resolver.rs
@@ -3,13 +3,14 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 use std::time::SystemTime;
 
 #[cfg(windows)]
 use winreg::{enums::*, RegKey};
 
-static REBUILT_PATH: OnceLock<String> = OnceLock::new();
+/// `None` until the first lookup, and reset to it by `invalidate_rebuilt_path` after an install.
+static REBUILT_PATH: RwLock<Option<String>> = RwLock::new(None);
 
 pub fn default_shell() -> String {
     #[cfg(windows)]
@@ -566,7 +567,37 @@ fn scrub_editor_environment(builder: &mut CommandBuilder) {
 }
 
 pub fn rebuilt_path() -> String {
-    REBUILT_PATH.get_or_init(build_rebuilt_path).clone()
+    if let Ok(cached) = REBUILT_PATH.read() {
+        if let Some(value) = cached.as_ref() {
+            return value.clone();
+        }
+    }
+    let built = build_rebuilt_path();
+    if let Ok(mut cached) = REBUILT_PATH.write() {
+        *cached = Some(built.clone());
+    }
+    built
+}
+
+/// Drops the cached PATH so the next lookup reads what an installer just wrote to the registry.
+/// Windows only hands a new environment to processes started after the change, and this one is
+/// long-lived: without this, a CLI installed from inside Alethe stays invisible until a restart.
+pub fn invalidate_rebuilt_path() {
+    if let Ok(mut cached) = REBUILT_PATH.write() {
+        *cached = None;
+    }
+}
+
+/// Re-reads the machine's environment, then reports the launcher for `command` — what an install
+/// screen calls to find out whether the CLI it was installing has actually landed.
+#[tauri::command]
+pub async fn refresh_cli_launcher(command: String) -> Option<String> {
+    tokio::task::spawn_blocking(move || {
+        invalidate_rebuilt_path();
+        find_windows_cli_launcher(&command).map(|path| path.to_string_lossy().to_string())
+    })
+    .await
+    .unwrap_or(None)
 }
 
 pub(crate) fn build_rebuilt_path() -> String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -331,6 +331,7 @@ pub fn run() {
             profiles::rename_profile,
             profiles::delete_profile,
             cli_resolver::find_cli_launcher,
+            cli_resolver::refresh_cli_launcher,
             cli_resolver::probe_install_toolchain,
             cli_resolver::agent_cli_version,
             cli_launch::cli_take_pending_open,

--- a/src/hooks/useAgentInstall.ts
+++ b/src/hooks/useAgentInstall.ts
@@ -3,10 +3,10 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from '
 import { installShellLine, type InstallMethod } from '../lib/agentInstall'
 import {
   agentCliVersion,
-  findCliLauncher,
   killPty,
   listenPtyData,
   listenPtyExit,
+  refreshCliLauncher,
   spawnPty,
   writePty,
 } from '../lib/tauri'
@@ -24,6 +24,13 @@ export type AgentInstallShadowConflict = { path: string }
 
 const MAX_LOG_CHARS = 12_000
 const PROMPT_SETTLE_MS = 400
+/**
+ * Installers do not agree on ending their shell: some hand the prompt back, some leave a progress
+ * bar or a pager behind, and a native script that only edits PATH may never return at all. Waiting
+ * for the PTY to exit is therefore not enough to notice a finished install, so the resolver is
+ * asked on this interval while the run is in flight.
+ */
+const VERIFY_POLL_MS = 1_500
 
 function trimLog(value: string): string {
   return value.length > MAX_LOG_CHARS ? value.slice(value.length - MAX_LOG_CHARS) : value
@@ -64,6 +71,7 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
   const ptyIdRef = useRef<string | null>(null)
   const cleanupRef = useRef<Array<() => void>>([])
   const disposedRef = useRef(false)
+  const settledRef = useRef(false)
 
   const teardown = useCallback(() => {
     cleanupRef.current.forEach((stop) => stop())
@@ -74,6 +82,17 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
     // Never leave the app-wide lock held by a run that is gone.
     if (busyAgent === lockKey) setBusyAgent(null)
   }, [lockKey])
+
+  /** First outcome wins: the shell exiting and the resolver noticing race each other. */
+  const settle = useCallback(
+    (outcome: 'success' | 'failed') => {
+      if (settledRef.current) return
+      settledRef.current = true
+      teardown()
+      setStatus(outcome)
+    },
+    [teardown],
+  )
 
   useEffect(() => {
     disposedRef.current = false
@@ -89,6 +108,7 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
       teardown()
       setLog('')
       setShadowConflict(null)
+      settledRef.current = false
       setStatus('running')
       setBusyAgent(lockKey)
 
@@ -96,6 +116,27 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
       // Only meaningful for an update of something already on PATH — a fresh install has
       // nothing to compare against, and verifyAbsent (uninstall) checks absence, not a version.
       const beforeVersion = command && !method.verifyAbsent ? await agentCliVersion(command) : null
+
+      /**
+       * Whether the machine now shows what this run was supposed to produce. The environment is
+       * re-read every time: an installer that adds itself to PATH only reaches processes started
+       * after it, so the app would otherwise keep answering from the PATH it booted with.
+       */
+      const verify = async (): Promise<boolean> => {
+        if (!command) return false
+        const found = await refreshCliLauncher(command).catch(() => null)
+        if (method.verifyAbsent) return !found
+        if (!found) return false
+        if (!beforeVersion) return true
+        // An update only counts once the version at that path actually moves.
+        const afterVersion = await agentCliVersion(command).catch(() => null)
+        return Boolean(afterVersion && afterVersion !== beforeVersion)
+      }
+
+      // Polling can only tell this run's effect apart from the state the machine was already in
+      // when the two differ. When the check passes before the installer even starts — a
+      // re-install, or a CLI whose version cannot be read — only the shell exiting settles it.
+      const alreadySatisfied = await verify()
 
       const ptyId = `agent-install:${lockKey}:${Date.now()}`
       try {
@@ -117,50 +158,50 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
         cleanupRef.current.push(
           await listenPtyExit(spawned.id, (payload) => {
             ptyIdRef.current = null
-            if (busyAgent === lockKey) setBusyAgent(null)
+            if (settledRef.current) return
             // `installShellLine` ends the shell with a bare `exit`, which carries the
             // installer command's own exit status. A non-zero code means the installer
             // itself reported failure (network error, permission denied, ...) — trust it
             // instead of falling through to the resolver, which would still find the
             // previous binary on PATH and misreport the run as a success.
-            if (payload.code !== 0) {
-              setStatus('failed')
-              return
-            }
-            if (!command) {
-              setStatus('failed')
+            if (payload.code !== 0 || !command) {
+              settle('failed')
               return
             }
             // A zero exit code still doesn't confirm the binary landed somewhere we
             // can launch it from, so ask the resolver.
-            void findCliLauncher(command)
-              .then(async (found) => {
-                if (disposedRef.current) return
-                const worked = method.verifyAbsent ? !found : Boolean(found)
-                if (!worked) {
-                  setStatus('failed')
+            void verify()
+              .then(async (worked) => {
+                if (disposedRef.current || settledRef.current) return
+                if (worked) {
+                  settle('success')
                   return
                 }
-                // The resolver found a binary and the installer exited clean, but if that
-                // binary's version is exactly what it was before, the installer likely
-                // reached a different install of this CLI than the one PATH resolves to —
-                // a shadowing install earlier on PATH that the update never touched.
-                if (beforeVersion && found) {
-                  const afterVersion = await agentCliVersion(command)
-                  if (disposedRef.current) return
-                  if (afterVersion && afterVersion === beforeVersion) {
-                    setShadowConflict({ path: found })
-                    setStatus('failed')
-                    return
-                  }
-                }
-                setStatus('success')
+                // The installer exited clean and a binary is still there, but its version never
+                // moved: the run likely reached a different install of this CLI than the one PATH
+                // resolves to — a shadowing copy the update never touched. Name it for the caller.
+                const found = beforeVersion
+                  ? await refreshCliLauncher(command).catch(() => null)
+                  : null
+                if (disposedRef.current) return
+                if (found) setShadowConflict({ path: found })
+                settle('failed')
               })
               .catch(() => {
-                if (!disposedRef.current) setStatus('failed')
+                if (!disposedRef.current) settle('failed')
               })
           }),
         )
+
+        // The shell exiting is only one of the two ways a run can end — see VERIFY_POLL_MS.
+        if (!alreadySatisfied) {
+          const poll = window.setInterval(() => {
+            void verify().then((worked) => {
+              if (worked && !disposedRef.current) settle('success')
+            })
+          }, VERIFY_POLL_MS)
+          cleanupRef.current.push(() => window.clearInterval(poll))
+        }
 
         await new Promise((resolve) => setTimeout(resolve, PROMPT_SETTLE_MS))
         if (disposedRef.current) return
@@ -171,11 +212,12 @@ export function useAgentInstall(agent: AgentType, lockKey: string = agent) {
         teardown()
       }
     },
-    [agent, lockKey, status, teardown],
+    [agent, lockKey, settle, status, teardown],
   )
 
   const reset = useCallback(() => {
     teardown()
+    settledRef.current = false
     setLog('')
     setShadowConflict(null)
     setStatus('idle')

--- a/src/lib/tauri/misc.ts
+++ b/src/lib/tauri/misc.ts
@@ -131,6 +131,15 @@ export async function findCliLauncher(agent: string): Promise<string | null> {
   return invoke<string | null>('find_cli_launcher', { agent })
 }
 
+/**
+ * Same lookup as `findCliLauncher`, but re-reads the machine's environment first. An installer
+ * that puts its CLI on PATH only reaches processes started afterwards, so this is what an install
+ * screen asks to see a CLI that landed while the app was already running.
+ */
+export async function refreshCliLauncher(command: string): Promise<string | null> {
+  return invoke<string | null>('refresh_cli_launcher', { command })
+}
+
 export async function probeInstallToolchain(): Promise<InstallToolchain> {
   return invoke<InstallToolchain>('probe_install_toolchain')
 }


### PR DESCRIPTION
Installing an agent CLI from inside Alethe could leave the dialog spinning forever, with no way out: Cancel is disabled while a run is in flight, so the screen could only be escaped by restarting the app.

Two things caused it. The run was only ever settled by the installer's shell exiting, and installers disagree about that -- some hand the prompt back, some leave a progress bar behind, and a native script that only edits PATH may never return. And `rebuilt_path` cached the machine's PATH in a `OnceLock`, read once per app run, so a CLI that adds itself to PATH during the install stayed invisible until a restart -- which made even a clean exit verify as a failure.

The install screen now polls the resolver while the run is in flight, and whichever notices the outcome first ends it; a `settledRef` keeps the two paths from fighting over the result. Polling is skipped when the check already passes before the installer starts, since it could not tell that apart from the run's own effect. The PATH cache became invalidatable, and `refresh_cli_launcher` re-reads the environment before resolving.

Tested on Windows 11 (installing the Cursor CLI, which is what surfaced it).

## What changed

  Installing an agent CLI from inside Alethe could leave the dialog spinning forever, with no way out: Cancel is disabled   
  while a run is in flight, so the screen could only be escaped by restarting the app.

    Two things caused it:
    1. The run was only ever settled by the installer's shell exiting, and installers disagree about that — some hand the     
  prompt back, some leave a progress bar behind, and a native script that only edits PATH may never return.
    2. `rebuilt_path` cached the machine's PATH in a `OnceLock`, read once per app run, so a CLI that adds itself to PATH     
  during the install stayed invisible until a restart — which made even a clean exit verify as a failure.

    The install screen now polls the resolver while the run is in flight, and whichever notices the outcome first ends it;    
  a `settledRef` keeps the two paths from fighting over the result. Polling is skipped when the check already passes before   
  the installer starts, since it could not tell that apart from the run's own effect. The PATH cache became invalidatable,    
  and `refresh_cli_launcher` re-reads the environment before resolving.

Closes #

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor / chore

## Screenshots

<!-- Required for any UI change. Before/after images or a short GIF. Delete if not applicable. -->

## Tested on

- [ ] Windows
- [ ] macOS
- [ ] Linux

<!-- Only check what you actually ran. "Windows only" is a fine answer. -->

## Checklist

- [x] `npm run build` passes (typecheck + build)
- [x] `npm test` passes
- [x] `npm run format` was run
- [x] User-facing strings go through `t()` and exist in both `en.ts` and `pt-BR.ts`
- [x] Colors/spacing use tokens from `styles/theme.css` — no hardcoded values
- [x] `docs/CHANGELOG.md` updated under `[Não lançado]` (features only)
